### PR TITLE
add DoTransform signatures that operate on Span<byte>

### DIFF
--- a/src/lcmsNET/Interop/Interop.Transform.cs
+++ b/src/lcmsNET/Interop/Interop.Transform.cs
@@ -168,6 +168,14 @@ namespace lcmsNET
             }
         }
 
+        internal unsafe static void DoTransform(IntPtr transform, ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer, int pixelCount)
+        {
+            fixed (void* pInBuffer = inputBuffer, pOutBuffer = outputBuffer)
+            {
+                DoTransform_Internal(transform, pInBuffer, pOutBuffer, pixelCount);
+            }
+        }
+
         [DllImport(Liblcms, EntryPoint = "cmsDoTransformLineStride", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void DoTransformLineStride_Internal(IntPtr transform,
                 /*const*/ void* inputBuffer,
@@ -184,6 +192,16 @@ namespace lcmsNET
                 int pixelsPerLine, int lineCount, int bytesPerLineIn, int bytesPerLineOut, int bytesPerPlaneIn, int bytesPerPlaneOut)
         {
             fixed (void* pInBuffer = &inputBuffer[0], pOutBuffer = &outputBuffer[0])
+            {
+                DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, pixelsPerLine, lineCount,
+                        bytesPerLineIn, bytesPerLineOut, bytesPerPlaneIn, bytesPerPlaneOut);
+            }
+        }
+
+        internal unsafe static void DoTransform(IntPtr transform, ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer,
+                int pixelsPerLine, int lineCount, int bytesPerLineIn, int bytesPerLineOut, int bytesPerPlaneIn, int bytesPerPlaneOut)
+        {
+            fixed (void* pInBuffer = inputBuffer, pOutBuffer = outputBuffer)
             {
                 DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, pixelsPerLine, lineCount,
                         bytesPerLineIn, bytesPerLineOut, bytesPerPlaneIn, bytesPerPlaneOut);

--- a/src/lcmsNET/Transform.cs
+++ b/src/lcmsNET/Transform.cs
@@ -255,6 +255,22 @@ namespace lcmsNET
         /// <summary>
         /// Translates a bitmap according to the parameters setup when creating the transform.
         /// </summary>
+        /// <param name="inputBuffer">A span of bytes containing the input bitmap.</param>
+        /// <param name="outputBuffer">A span of bytes to contain the output bitmap.</param>
+        /// <param name="pixelCount">The number of pixels to be transformed.</param>
+        /// <exception cref="ObjectDisposedException">
+        /// The Profile has already been disposed.
+        /// </exception>
+        public void DoTransform(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer, int pixelCount)
+        {
+            EnsureNotClosed();
+
+            Interop.DoTransform(handle, inputBuffer, outputBuffer, pixelCount);
+        }
+
+        /// <summary>
+        /// Translates a bitmap according to the parameters setup when creating the transform.
+        /// </summary>
         /// <param name="inputBuffer">An array of bytes containing the input bitmap.</param>
         /// <param name="outputBuffer">An array of bytes to contain the output bitmap.</param>
         /// <param name="pixelsPerLine">The number of pixels per line; same on input and in output.</param>
@@ -275,6 +291,37 @@ namespace lcmsNET
         /// </para>
         /// </remarks>
         public void DoTransform(byte[] inputBuffer, byte[] outputBuffer, int pixelsPerLine, int lineCount,
+                int bytesPerLineIn, int bytesPerLineOut, int bytesPerPlaneIn, int bytesPerPlaneOut)
+        {
+            EnsureNotClosed();
+
+            Interop.DoTransform(handle, inputBuffer, outputBuffer, pixelsPerLine, lineCount,
+                    bytesPerLineIn, bytesPerLineOut, bytesPerPlaneIn, bytesPerPlaneOut);
+        }
+
+        /// <summary>
+        /// Translates a bitmap according to the parameters setup when creating the transform.
+        /// </summary>
+        /// <param name="inputBuffer">A span of bytes containing the input bitmap.</param>
+        /// <param name="outputBuffer">A span of bytes to contain the output bitmap.</param>
+        /// <param name="pixelsPerLine">The number of pixels per line; same on input and in output.</param>
+        /// <param name="lineCount">The number of lines; same on input as in output.</param>
+        /// <param name="bytesPerLineIn">The distance in bytes from one line to the next on the input bitmap.</param>
+        /// <param name="bytesPerLineOut">The distance in bytes from one line to the next in the output bitmap.</param>
+        /// <param name="bytesPerPlaneIn">The distance in bytes from one plane to the next inside a line on the input bitmap.</param>
+        /// <param name="bytesPerPlaneOut">The distance in bytes from one plane to the next inside a line in the output bitmap.</param>
+        /// <exception cref="ObjectDisposedException">
+        /// The Transform has already been disposed.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="bytesPerPlaneIn"/> and <paramref name="bytesPerPlaneOut"/> are only used in planar formats.
+        /// </para>
+        /// <para>
+        /// Requires Little CMS version 2.8 or later.
+        /// </para>
+        /// </remarks>
+        public void DoTransform(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer, int pixelsPerLine, int lineCount,
                 int bytesPerLineIn, int bytesPerLineOut, int bytesPerPlaneIn, int bytesPerPlaneOut)
         {
             EnsureNotClosed();


### PR DESCRIPTION
Using `Span<byte>` can allow some code to avoid allocating a new `byte[]` when calling into lcms.

The `netstandard2.0` build succeeded for me locally but it seems like this might require a `System.Memory` package dependency on target frameworks that don't have `Span<>` as part of their runtime, or maybe conditional compilation -- I don't fully understand best practices for this.