### PR TITLE
Add documentation section with Code Wiki link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,10 @@ using (var transform = Transform.Create(input, Cms.TYPE_RGB_8, output, Cms.TYPE_
 ## Other
 See the unit tests for examples of how to invoke each supported method and property.
 
+## Documentation
+
+Why not check out the Gemini-generated documentation for this project on
+[Code Wiki](https://codewiki.google/github.com/jrshoare/lcmsnet)?
+
 # Future work
 * Improved [documentation](docs/index.md)


### PR DESCRIPTION
Added a "Documentation" section to the README, featuring a link to Gemini-generated project documentation hosted on Code Wiki. This provides users with easy access to comprehensive project information.