### PR TITLE
Improve native AOT compatibility

### DIFF
--- a/src/lcmsNET/Cms.cs
+++ b/src/lcmsNET/Cms.cs
@@ -1390,6 +1390,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ICCMeasurementConditions
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<ICCMeasurementConditions>
+#endif
     {
         /// <summary>
         /// The standard observer.
@@ -1421,7 +1424,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="ICCMeasurementConditions"/> instance.</returns>
-        internal static ICCMeasurementConditions FromHandle(IntPtr handle)
+        public static ICCMeasurementConditions FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<ICCMeasurementConditions>(handle);
         }
@@ -1432,6 +1435,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct ICCViewingConditions
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<ICCViewingConditions>
+#endif
     {
         /// <summary>
         /// Un-normalized CIEXYZ values for illuminant (in which Y is in cd/m²).
@@ -1452,7 +1458,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="ICCViewingConditions"/> instance.</returns>
-        internal static ICCViewingConditions FromHandle(IntPtr handle)
+        public static ICCViewingConditions FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<ICCViewingConditions>(handle);
         }
@@ -1466,6 +1472,9 @@ namespace lcmsNET
     /// </remarks>
     [StructLayout(LayoutKind.Sequential)]
     public struct VideoSignalType
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<VideoSignalType>
+#endif
     {
         /// <summary>
         /// Colour primaries code point.
@@ -1489,7 +1498,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="VideoSignalType"/> instance.</returns>
-        internal static VideoSignalType FromHandle(IntPtr handle)
+        public static VideoSignalType FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<VideoSignalType>(handle);
         }

--- a/src/lcmsNET/ColorantOrder.cs
+++ b/src/lcmsNET/ColorantOrder.cs
@@ -28,6 +28,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct ColorantOrder
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<ColorantOrder>
+#endif
     {
         [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)]
         private readonly byte[] _;
@@ -52,14 +55,14 @@ namespace lcmsNET
         /// Explicitly converts a <see cref="byte"/> array of 16 values to a <see cref="ColorantOrder"/>.
         /// </summary>
         /// <param name="bytes">The byte array to be converted.</param>
-        public static explicit operator ColorantOrder(byte[] bytes) => new ColorantOrder(bytes);
+        public static explicit operator ColorantOrder(byte[] bytes) => new(bytes);
 
         /// <summary>
         /// Marshals data from an unmanaged block of memory to a newly allocated <see cref="ColorantOrder"/> object.
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="ColorantOrder"/> instance.</returns>
-        internal static ColorantOrder FromHandle(IntPtr handle)
+        public static ColorantOrder FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<ColorantOrder>(handle);
         }

--- a/src/lcmsNET/Colorimetric.cs
+++ b/src/lcmsNET/Colorimetric.cs
@@ -28,6 +28,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct CIEXYZ
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<CIEXYZ>
+#endif
     {
         /// <summary>
         /// XYZ X.
@@ -63,7 +66,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="CIEXYZ"/> instance.</returns>
-        internal static CIEXYZ FromHandle(IntPtr handle)
+        public static CIEXYZ FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<CIEXYZ>(handle);
         }
@@ -219,6 +222,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct CIEXYZTRIPLE
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<CIEXYZTRIPLE>
+#endif
     {
         /// <summary>
         /// The CIEXYZ Red component.
@@ -238,7 +244,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="CIEXYZTRIPLE"/> instance.</returns>
-        internal static CIEXYZTRIPLE FromHandle(IntPtr handle)
+        public static CIEXYZTRIPLE FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<CIEXYZTRIPLE>(handle);
         }
@@ -249,6 +255,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct CIExyYTRIPLE
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<CIExyYTRIPLE>
+#endif
     {
         /// <summary>
         /// The CIExyY Red component.
@@ -268,7 +277,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="CIExyYTRIPLE"/> instance.</returns>
-        internal static CIExyYTRIPLE FromHandle(IntPtr handle)
+        public static CIExyYTRIPLE FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<CIExyYTRIPLE>(handle);
         }

--- a/src/lcmsNET/Colorimetric.cs
+++ b/src/lcmsNET/Colorimetric.cs
@@ -32,17 +32,14 @@ namespace lcmsNET
         /// <summary>
         /// XYZ X.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double X;
         /// <summary>
         /// XYZ Y.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double Y;
         /// <summary>
         /// XYZ Z.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double Z;
 
         /// <summary>
@@ -50,7 +47,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="whitePoint">The white point to be used in the conversion.</param>
         /// <returns>The corresponding <see cref="CIELab"/> value.</returns>
-        public CIELab ToLab(in CIEXYZ whitePoint)
+        public readonly CIELab ToLab(in CIEXYZ whitePoint)
         {
             Interop.XYZ2Lab(whitePoint, out CIELab lab, this);
             return lab;
@@ -91,17 +88,14 @@ namespace lcmsNET
         /// <summary>
         /// xyY x.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double x;
         /// <summary>
         /// xyY y.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double y;
         /// <summary>
         /// xyY Y.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double Y;
 
         /// <summary>
@@ -132,7 +126,6 @@ namespace lcmsNET
         /// <remarks>
         /// Black is 0 and white is 100.
         /// </remarks>
-        [MarshalAs(UnmanagedType.R8)]
         public double L;
         /// <summary>
         /// CIELAB a axis value representing the green-red opponent colors.
@@ -140,7 +133,6 @@ namespace lcmsNET
         /// <remarks>
         /// Negative values are towards green and positive values towards red.
         /// </remarks>
-        [MarshalAs(UnmanagedType.R8)]
         public double a;
         /// <summary>
         /// CIELAB b axis value representing the blue-yellow opponent colors.
@@ -148,7 +140,6 @@ namespace lcmsNET
         /// <remarks>
         /// Negative values are towards blue and positive values towards yellow.
         /// </remarks>
-        [MarshalAs(UnmanagedType.R8)]
         public double b;
 
         /// <summary>
@@ -156,7 +147,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="whitePoint">The white point to be used in the conversion.</param>
         /// <returns>The corresponding <see cref="CIEXYZ"/> value.</returns>
-        public CIEXYZ ToXYZ(in CIEXYZ whitePoint)
+        public readonly CIEXYZ ToXYZ(in CIEXYZ whitePoint)
         {
             Interop.Lab2XYZ(whitePoint, out CIEXYZ xyz, this);
             return xyz;
@@ -182,17 +173,14 @@ namespace lcmsNET
         /// <summary>
         /// CIELCh L lightness value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double L;
         /// <summary>
         /// CIELCh C chroma value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double C;
         /// <summary>
         /// CIELCh h hue value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double h;
 
         /// <summary>
@@ -215,17 +203,14 @@ namespace lcmsNET
         /// <summary>
         /// CIE CAM02 J lightness value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double J;
         /// <summary>
         /// CIE CAM02 C chroma value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double C;
         /// <summary>
         /// CIE CAM02 h hue value.
         /// </summary>
-        [MarshalAs(UnmanagedType.R8)]
         public double h;
     }
 
@@ -485,10 +470,12 @@ namespace lcmsNET
         /// </summary>
         /// <param name="xyY">The <see cref="CIExyY"/> value to be converted.</param>
         /// <returns>The corresponding <see cref="CIEXYZ"/> value.</returns>
+#pragma warning disable IDE1006 // Naming Styles
         public static CIEXYZ xyY2XYZ(in CIExyY xyY)
         {
             Interop.xyY2XYZ(out CIEXYZ xyz, xyY);
             return xyz;
         }
+#pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/lcmsNET/Dict.cs
+++ b/src/lcmsNET/Dict.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 namespace lcmsNET
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct _DictEntry
+    internal struct InternalDictEntry
     {
         public IntPtr Next;         // struct cmsDICTentry struct *
         public IntPtr DisplayName;  // cmsMLU *
@@ -42,6 +42,9 @@ namespace lcmsNET
     /// Represents a dictionary of <see cref="DictEntry"/> items.
     /// </summary>
     public sealed class Dict : TagBase<Dict>, IEnumerable<DictEntry>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<Dict>
+#endif
     {
         internal Dict(IntPtr handle, Context context = null, bool isOwner = true)
             : base(handle, context, isOwner)
@@ -58,7 +61,7 @@ namespace lcmsNET
         /// <exception cref="LcmsNETException">
         /// The <paramref name="handle"/> is <see cref="IntPtr.Zero"/>.
         /// </exception>
-        internal static Dict FromHandle(IntPtr handle)
+        public static Dict FromHandle(IntPtr handle)
         {
             return new Dict(handle, context: null, isOwner: false);
         }

--- a/src/lcmsNET/DictEntry.cs
+++ b/src/lcmsNET/DictEntry.cs
@@ -30,7 +30,7 @@ namespace lcmsNET
     {
         internal DictEntry(IntPtr handle)
         {
-            var entry = Marshal.PtrToStructure<_DictEntry>(handle);
+            var entry = Marshal.PtrToStructure<InternalDictEntry>(handle);
 
             Handle = handle;
             DisplayName = entry.DisplayName != IntPtr.Zero

--- a/src/lcmsNET/ICCData.cs
+++ b/src/lcmsNET/ICCData.cs
@@ -29,6 +29,9 @@ namespace lcmsNET
     /// Represents a data structure that contains either 7-bit ASCII or binary data.
     /// </summary>
     public class ICCData
+#if NET7_0_OR_GREATER
+        : IHandleConvertible
+#endif
     {
         /// <summary>
         /// 7-bit ASCII data type.
@@ -65,7 +68,11 @@ namespace lcmsNET
         /// </remarks>
         public ICCData(string s)
         {
+#if NET5_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(s);
+#else
             if (s is null) throw new ArgumentNullException(nameof(s));
+#endif
 
             Flag = ASCII;
             Data = Encoding.ASCII.GetBytes(s);
@@ -84,7 +91,11 @@ namespace lcmsNET
         /// </remarks>
         public ICCData(byte[] bytes)
         {
+#if NET5_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(bytes);
+#else
             if (bytes is null) throw new ArgumentNullException(nameof(bytes));
+#endif
 
             Flag = Binary;
             Data = bytes;
@@ -137,14 +148,23 @@ namespace lcmsNET
             }
 
             if (flag == ASCII)
-                return new ICCData(Helper.ToString(data).TrimEnd(new char[] { '\0' })); // remove 00h terminator byte
+                return new ICCData(Helper.ToString(data).TrimEnd(['\0'])); // remove 00h terminator byte
             else if (flag == Binary)
                 return new ICCData(data);
             else
-                throw new ArgumentException($"Value must be either {ASCII} or {Binary}.", nameof(flag));
+                throw new ArgumentException("Flag must be either ASCII or Binary.");
         }
 
-        internal IntPtr ToHandle()
+        /// <summary>
+        /// Converts the current instance to a native handle that can be used by the underlying implementation.
+        /// </summary>
+        /// <returns>A native handle that represents the current instance.</returns>
+#if NET7_0_OR_GREATER
+        public
+#else
+        internal
+#endif
+            IntPtr ToHandle()
         {
             int cb = sizeof(uint) + sizeof(uint) + Data.Length;
             int nulLen = (Flag == ASCII) ? 1 : 0;

--- a/src/lcmsNET/ICCData.cs
+++ b/src/lcmsNET/ICCData.cs
@@ -30,7 +30,7 @@ namespace lcmsNET
     /// </summary>
     public class ICCData
 #if NET7_0_OR_GREATER
-        : IHandleConvertible
+        : IHandleConvertible, ICreatableFromHandle<ICCData>
 #endif
     {
         /// <summary>
@@ -132,7 +132,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="ICCData"/> instance.</returns>
-        internal static ICCData FromHandle(IntPtr handle)
+        public static ICCData FromHandle(IntPtr handle)
         {
             IntPtr ptr = handle;
             uint len = (uint)Marshal.ReadInt32(ptr); // len

--- a/src/lcmsNET/Interop/Interop.CAM02.cs
+++ b/src/lcmsNET/Interop/Interop.CAM02.cs
@@ -25,41 +25,74 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIECAM02Init")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CIECAM02Init_Internal(
+                IntPtr contextID,
+                in ViewingConditions conditions);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIECAM02Init", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CIECAM02Init_Internal(
                 IntPtr contextID,
                 in ViewingConditions conditions);
+#endif
 
         internal static IntPtr CIECAM02Init(IntPtr contextID, in ViewingConditions conditions)
         {
             return CIECAM02Init_Internal(contextID, conditions);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIECAM02Done")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void CIECAM02Done_Internal(
+                IntPtr model);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIECAM02Done", CallingConvention = CallingConvention.StdCall)]
         private static extern void CIECAM02Done_Internal(
                 IntPtr model);
+#endif
 
         internal static void CIECAM02Done(IntPtr model)
         {
             CIECAM02Done_Internal(model);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIECAM02Forward")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void CIECAM02Forward_Internal(
+                IntPtr model,
+                in CIEXYZ xyz,
+                out JCh jch);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIECAM02Forward", CallingConvention = CallingConvention.StdCall)]
         private static extern void CIECAM02Forward_Internal(
                 IntPtr model,
                 in CIEXYZ xyz,
                 out JCh jch);
+#endif
 
         internal static void CIECAM02Forward(IntPtr model, in CIEXYZ xyz, out JCh jch)
         {
             CIECAM02Forward_Internal(model, xyz, out jch);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIECAM02Reverse")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void CIECAM02Reverse_Internal(
+                IntPtr model,
+                in JCh jch,
+                out CIEXYZ xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIECAM02Reverse", CallingConvention = CallingConvention.StdCall)]
         private static extern void CIECAM02Reverse_Internal(
                 IntPtr model,
                 in JCh jch,
                 out CIEXYZ xyz);
+#endif
 
         internal static void CIECAM02Reverse(IntPtr model, in JCh jch, out CIEXYZ xyz)
         {

--- a/src/lcmsNET/Interop/Interop.Colorimetric.cs
+++ b/src/lcmsNET/Interop/Interop.Colorimetric.cs
@@ -19,48 +19,81 @@
 // SOFTWARE.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace lcmsNET
 {
-    internal static partial class Interop
+    internal unsafe static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsXYZ2Lab")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void XYZ2Lab_Internal(in CIEXYZ whitePoint, out CIELab lab, in CIEXYZ xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsXYZ2Lab", CallingConvention = CallingConvention.StdCall)]
         private static extern void XYZ2Lab_Internal(in CIEXYZ whitePoint, out CIELab lab, in CIEXYZ xyz);
+#endif
 
         internal static void XYZ2Lab(in CIEXYZ whitePoint, out CIELab lab, in CIEXYZ xyz)
         {
             XYZ2Lab_Internal(whitePoint, out lab, xyz);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLab2XYZ")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void Lab2XYZ_Internal(in CIEXYZ whitePoint, out CIEXYZ xyz, in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLab2XYZ", CallingConvention = CallingConvention.StdCall)]
         private static extern void Lab2XYZ_Internal(in CIEXYZ whitePoint, out CIEXYZ xyz, in CIELab lab);
+#endif
 
         internal static void Lab2XYZ(in CIEXYZ whitePoint, out CIEXYZ xyz, in CIELab lab)
         {
             Lab2XYZ_Internal(whitePoint, out xyz, lab);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLab2LCh")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void Lab2LCh_Internal(out CIELCh lch, in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLab2LCh", CallingConvention = CallingConvention.StdCall)]
         private static extern void Lab2LCh_Internal(out CIELCh lch, in CIELab lab);
+#endif
 
         internal static void Lab2LCh(out CIELCh lch, in CIELab lab)
         {
             Lab2LCh_Internal(out lch, lab);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLCh2Lab")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void LCh2Lab_Internal(out CIELab lab, in CIELCh lch);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLCh2Lab", CallingConvention = CallingConvention.StdCall)]
         private static extern void LCh2Lab_Internal(out CIELab lab, in CIELCh lch);
+#endif
 
         internal static void LCh2Lab(out CIELab lab, in CIELCh lch)
         {
             LCh2Lab_Internal(out lab, lch);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLabEncoded2Float")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static unsafe partial void LabEncoded2Float_Internal(
+                out CIELab lab,
+                /*const*/ ushort* wLab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLabEncoded2Float", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void LabEncoded2Float_Internal(
                 out CIELab lab,
                 /*const*/ ushort* wLab);
+#endif
 
         internal static void LabEncoded2Float(out CIELab lab, ReadOnlySpan<ushort> wLab)
         {
@@ -73,20 +106,36 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsFloat2LabEncoded")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void Float2LabEncoded_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] [Out] ushort[] wLab,
+                in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFloat2LabEncoded", CallingConvention = CallingConvention.StdCall)]
         private static extern void Float2LabEncoded_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] ushort[] wLab,
                 in CIELab lab);
+#endif
 
         internal static void Float2LabEncoded(in CIELab lab, ushort[] wLab)
         {
             Float2LabEncoded_Internal(wLab, lab);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLabEncoded2FloatV2")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static unsafe partial void LabEncoded2FloatV2_Internal(
+                out CIELab lab,
+                /*const*/ ushort* wLab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLabEncoded2FloatV2", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void LabEncoded2FloatV2_Internal(
                 out CIELab lab,
                 /*const*/ ushort* wLab);
+#endif
 
         internal static void LabEncoded2FloatV2(out CIELab lab, ReadOnlySpan<ushort> wLab)
         {
@@ -99,20 +148,36 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsFloat2LabEncodedV2")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void Float2LabEncodedV2_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] [Out] ushort[] wLab,
+                in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFloat2LabEncodedV2", CallingConvention = CallingConvention.StdCall)]
         private static extern void Float2LabEncodedV2_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] ushort[] wLab,
                 in CIELab lab);
+#endif
 
         internal static void Float2LabEncodedV2(in CIELab lab, ushort[] wLab)
         {
             Float2LabEncodedV2_Internal(wLab, lab);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsXYZEncoded2Float")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static unsafe partial void XYZEncoded2Float_Internal(
+                out CIEXYZ fxyz,
+                /*const*/ ushort* xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsXYZEncoded2Float", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void XYZEncoded2Float_Internal(
                 out CIEXYZ fxyz,
                 /*const*/ ushort* xyz);
+#endif
 
         internal static void XYZEncoded2Float(out CIEXYZ fxyz, ReadOnlySpan<ushort> xyz)
         {
@@ -125,16 +190,34 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsFloat2XYZEncoded")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void Float2XYZEncoded_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] [Out] ushort[] xyz,
+                in CIEXYZ fxyz);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFloat2XYZEncoded", CallingConvention = CallingConvention.StdCall)]
         private static extern void Float2XYZEncoded_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] ushort[] xyz,
                 in CIEXYZ fxyz);
+#endif
 
         internal static void Float2XYZEncoded(in CIEXYZ fxyz, ushort[] xyz)
         {
             Float2XYZEncoded_Internal(xyz, fxyz);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDesaturateLab")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial int DesaturateLab_Internal(
+                ref CIELab lab,
+                [MarshalAs(UnmanagedType.R8)] double aMax,
+                [MarshalAs(UnmanagedType.R8)] double aMin,
+                [MarshalAs(UnmanagedType.R8)] double bMax,
+                [MarshalAs(UnmanagedType.R8)] double bMin);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDesaturateLab", CallingConvention = CallingConvention.StdCall)]
         private static extern int DesaturateLab_Internal(
                 ref CIELab lab,
@@ -142,12 +225,21 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.R8)] double aMin,
                 [MarshalAs(UnmanagedType.R8)] double bMax,
                 [MarshalAs(UnmanagedType.R8)] double bMin);
+#endif
 
         internal static int DesaturateLab(ref CIELab lab, double aMax, double aMin, double bMax, double bMin)
         {
             return DesaturateLab_Internal(ref lab, aMax, aMin, bMax, bMin);
         }
 
+#if NET7_0_OR_GREATER
+        // Use DllImport variant for ref-returning natives to avoid partial-method accessibility issue
+        [LibraryImport(Liblcms, EntryPoint = "cmsD50_XYZ")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial CIEXYZ* D50_XYZ_Internal();
+
+        internal static ref readonly CIEXYZ GetD50_XYZ() => ref Unsafe.AsRef<CIEXYZ>(D50_XYZ_Internal());
+#else
         [DllImport(Liblcms, EntryPoint = "cmsD50_XYZ", CallingConvention = CallingConvention.StdCall)]
         private static extern ref CIEXYZ D50_XYZ_Internal();
 
@@ -155,7 +247,15 @@ namespace lcmsNET
         {
             return D50_XYZ_Internal();
         }
+#endif
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsD50_xyY")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial CIExyY* D50_xyY_Internal();
+
+        internal static ref readonly CIExyY GetD50_xyY() => ref Unsafe.AsRef<CIExyY>(D50_xyY_Internal());
+#else
         [DllImport(Liblcms, EntryPoint = "cmsD50_xyY", CallingConvention = CallingConvention.StdCall)]
         private static extern ref CIExyY D50_xyY_Internal();
 
@@ -163,21 +263,36 @@ namespace lcmsNET
         {
             return D50_xyY_Internal();
         }
+#endif
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsXYZ2xyY")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void XYZ2xyY_Internal(out CIExyY xyY, in CIEXYZ xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsXYZ2xyY", CallingConvention = CallingConvention.StdCall)]
         private static extern void XYZ2xyY_Internal(out CIExyY xyY, in CIEXYZ xyz);
+#endif
 
         internal static void XYZ2xyY(out CIExyY xyY, in CIEXYZ xyz)
         {
             XYZ2xyY_Internal(out xyY, xyz);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsxyY2XYZ")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(CallConvStdcall) })]
+        private static partial void xyY2XYZ_Internal(out CIEXYZ xyz, in CIExyY xyY);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsxyY2XYZ", CallingConvention = CallingConvention.StdCall)]
         private static extern void xyY2XYZ_Internal(out CIEXYZ xyz, in CIExyY xyY);
+#endif
 
+#pragma warning disable IDE1006 // Naming Styles
         internal static void xyY2XYZ(out CIEXYZ xyz, in CIExyY xyY)
         {
             xyY2XYZ_Internal(out xyz, xyY);
         }
+#pragma warning restore IDE1006 // Naming Styles
     }
 }

--- a/src/lcmsNET/Interop/Interop.Context.cs
+++ b/src/lcmsNET/Interop/Interop.Context.cs
@@ -26,67 +26,113 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateContext")]
+        private static partial IntPtr CreateContext_Internal(
+                IntPtr plugin,
+                IntPtr userData);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateContext", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateContext_Internal(
                 IntPtr plugin,
                 IntPtr userData);
+#endif
 
         internal static IntPtr CreateContext(IntPtr plugin, IntPtr userData)
         {
             return CreateContext_Internal(plugin, userData);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsDeleteContext")]
+        private static partial void DeleteContext_Internal(
+            IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDeleteContext", CallingConvention = CallingConvention.StdCall)]
         private static extern void DeleteContext_Internal(
             IntPtr handle);
+#endif
 
         internal static void DeleteContext(IntPtr handle)
         {
             DeleteContext_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsDupContext")]
+        private static partial IntPtr DuplicateContext_Internal(
+            IntPtr handle,
+            IntPtr userData);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDupContext", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DuplicateContext_Internal(
             IntPtr handle,
             IntPtr userData);
+#endif
 
         internal static IntPtr DuplicateContext(IntPtr handle, IntPtr userData)
         {
             return DuplicateContext_Internal(handle, userData);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetContextUserData")]
+        private static partial IntPtr GetContextUserData_Internal(
+            IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetContextUserData", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetContextUserData_Internal(
             IntPtr handle);
+#endif
 
         internal static IntPtr GetContextUserData(IntPtr handle)
         {
             return GetContextUserData_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPluginTHR")]
+        private static partial int PluginTHR_Internal(
+            IntPtr handle,
+            IntPtr plugin);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPluginTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern int PluginTHR_Internal(
             IntPtr handle,
             IntPtr plugin);
+#endif
 
         internal static int RegisterContextPlugins(IntPtr handle, IntPtr plugin)
         {
             return PluginTHR_Internal(handle, plugin);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsUnregisterPluginsTHR")]
+        private static partial int UnregisterPluginsTHR_Internal(
+            IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsUnregisterPluginsTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern int UnregisterPluginsTHR_Internal(
             IntPtr handle);
+#endif
 
         internal static void UnregisterContextPlugins(IntPtr handle)
         {
             UnregisterPluginsTHR_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandlerTHR")]
+        private static partial int SetLogErrorHandlerTHR_Internal(
+                IntPtr handle,
+                IntPtr fn);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetLogErrorHandlerTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern int SetLogErrorHandlerTHR_Internal(
                 IntPtr handle,
                 IntPtr fn);
+#endif
 
         internal static void SetContextErrorHandler(IntPtr handle, ErrorHandler handler)
         {
@@ -94,42 +140,72 @@ namespace lcmsNET
             SetLogErrorHandlerTHR_Internal(handle, fn);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodesTHR")]
+        private static partial void GetAlarmCodesTHR_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetAlarmCodesTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetAlarmCodesTHR_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#endif
 
         internal static void GetAlarmCodesTHR(IntPtr handle, ushort[] alarmCodes)
         {
             GetAlarmCodesTHR_Internal(handle, alarmCodes);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodesTHR")]
+        private static partial void SetAlarmCodesTHR_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetAlarmCodesTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetAlarmCodesTHR_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#endif
 
         internal static void SetAlarmCodesTHR(IntPtr handle, ushort[] alarmCodes)
         {
             SetAlarmCodesTHR_Internal(handle, alarmCodes);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetAdaptationStateTHR")]
+        private static partial double SetAdaptationStateTHR_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R8)] double adaptationState);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetAdaptationStateTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern double SetAdaptationStateTHR_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double adaptationState);
+#endif
 
         internal static double SetAdaptationStateTHR(IntPtr handle, double adaptationState)
         {
             return SetAdaptationStateTHR_Internal(handle, adaptationState);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetSupportedIntentsTHR")]
+        private static partial uint GetSupportedIntents_InternalTHR(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint nMax,
+                IntPtr Codes,
+                IntPtr Descriptions);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetSupportedIntentsTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetSupportedIntents_InternalTHR(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint nMax,
                 IntPtr Codes,
                 IntPtr Descriptions);
+#endif
 
         internal static IEnumerable<(uint code, string description)> GetSupportedIntentsTHR(IntPtr handle)
         {

--- a/src/lcmsNET/Interop/Interop.Context.cs
+++ b/src/lcmsNET/Interop/Interop.Context.cs
@@ -144,12 +144,12 @@ namespace lcmsNET
         [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodesTHR")]
         private static partial void GetAlarmCodesTHR_Internal(
                 IntPtr handle,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [Out] ushort[] alarmCodes);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsGetAlarmCodesTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetAlarmCodesTHR_Internal(
                 IntPtr handle,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [Out] ushort[] alarmCodes);
 #endif
 
         internal static void GetAlarmCodesTHR(IntPtr handle, ushort[] alarmCodes)
@@ -161,12 +161,12 @@ namespace lcmsNET
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodesTHR")]
         private static partial void SetAlarmCodesTHR_Internal(
                 IntPtr handle,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [In] ushort[] alarmCodes);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsSetAlarmCodesTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetAlarmCodesTHR_Internal(
                 IntPtr handle,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [In] ushort[] alarmCodes);
 #endif
 
         internal static void SetAlarmCodesTHR(IntPtr handle, ushort[] alarmCodes)

--- a/src/lcmsNET/Interop/Interop.Context.cs
+++ b/src/lcmsNET/Interop/Interop.Context.cs
@@ -26,7 +26,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateContext")]
         private static partial IntPtr CreateContext_Internal(
                 IntPtr plugin,
@@ -43,7 +43,7 @@ namespace lcmsNET
             return CreateContext_Internal(plugin, userData);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsDeleteContext")]
         private static partial void DeleteContext_Internal(
             IntPtr handle);
@@ -58,7 +58,7 @@ namespace lcmsNET
             DeleteContext_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsDupContext")]
         private static partial IntPtr DuplicateContext_Internal(
             IntPtr handle,
@@ -75,7 +75,7 @@ namespace lcmsNET
             return DuplicateContext_Internal(handle, userData);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetContextUserData")]
         private static partial IntPtr GetContextUserData_Internal(
             IntPtr handle);
@@ -90,7 +90,7 @@ namespace lcmsNET
             return GetContextUserData_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPluginTHR")]
         private static partial int PluginTHR_Internal(
             IntPtr handle,
@@ -107,7 +107,7 @@ namespace lcmsNET
             return PluginTHR_Internal(handle, plugin);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsUnregisterPluginsTHR")]
         private static partial int UnregisterPluginsTHR_Internal(
             IntPtr handle);
@@ -122,7 +122,7 @@ namespace lcmsNET
             UnregisterPluginsTHR_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandlerTHR")]
         private static partial int SetLogErrorHandlerTHR_Internal(
                 IntPtr handle,
@@ -140,7 +140,7 @@ namespace lcmsNET
             SetLogErrorHandlerTHR_Internal(handle, fn);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodesTHR")]
         private static partial void GetAlarmCodesTHR_Internal(
                 IntPtr handle,
@@ -157,7 +157,7 @@ namespace lcmsNET
             GetAlarmCodesTHR_Internal(handle, alarmCodes);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodesTHR")]
         private static partial void SetAlarmCodesTHR_Internal(
                 IntPtr handle,
@@ -174,7 +174,7 @@ namespace lcmsNET
             SetAlarmCodesTHR_Internal(handle, alarmCodes);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAdaptationStateTHR")]
         private static partial double SetAdaptationStateTHR_Internal(
                 IntPtr handle,
@@ -191,7 +191,7 @@ namespace lcmsNET
             return SetAdaptationStateTHR_Internal(handle, adaptationState);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetSupportedIntentsTHR")]
         private static partial uint GetSupportedIntents_InternalTHR(
                 IntPtr handle,

--- a/src/lcmsNET/Interop/Interop.Context.cs
+++ b/src/lcmsNET/Interop/Interop.Context.cs
@@ -109,11 +109,11 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsUnregisterPluginsTHR")]
-        private static partial int UnregisterPluginsTHR_Internal(
+        private static partial void UnregisterPluginsTHR_Internal(
             IntPtr handle);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsUnregisterPluginsTHR", CallingConvention = CallingConvention.StdCall)]
-        private static extern int UnregisterPluginsTHR_Internal(
+        private static extern void UnregisterPluginsTHR_Internal(
             IntPtr handle);
 #endif
 
@@ -124,12 +124,12 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandlerTHR")]
-        private static partial int SetLogErrorHandlerTHR_Internal(
+        private static partial void SetLogErrorHandlerTHR_Internal(
                 IntPtr handle,
                 IntPtr fn);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsSetLogErrorHandlerTHR", CallingConvention = CallingConvention.StdCall)]
-        private static extern int SetLogErrorHandlerTHR_Internal(
+        private static extern void SetLogErrorHandlerTHR_Internal(
                 IntPtr handle,
                 IntPtr fn);
 #endif
@@ -212,7 +212,7 @@ namespace lcmsNET
             // get intent count first
             uint count = GetSupportedIntents_InternalTHR(handle, 0, IntPtr.Zero, IntPtr.Zero);
 
-            List<(uint code, string description)> result = new List<(uint code, string description)>();
+            List<(uint code, string description)> result = [];
 
             unsafe
             {

--- a/src/lcmsNET/Interop/Interop.DeltaE.cs
+++ b/src/lcmsNET/Interop/Interop.DeltaE.cs
@@ -24,6 +24,18 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIE2000DeltaE")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        [return: MarshalAs(UnmanagedType.R8)]
+        private static partial double CIE2000DeltaE_Internal(
+            in CIELab lab1,
+            in CIELab lab2,
+            [MarshalAs(UnmanagedType.R8)] double kL,
+            [MarshalAs(UnmanagedType.R8)] double kC,
+            [MarshalAs(UnmanagedType.R8)] double kH
+            );
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIE2000DeltaE", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.R8)]
         private static extern double CIE2000DeltaE_Internal(
@@ -33,23 +45,43 @@ namespace lcmsNET
             [MarshalAs(UnmanagedType.R8)] double kC,
             [MarshalAs(UnmanagedType.R8)] double kH
             );
+#endif
 
         internal static double CIE2000DeltaE(in CIELab lab1, in CIELab lab2, double kL = 1.0, double kC = 1.0, double kH = 1.0)
         {
             return CIE2000DeltaE_Internal(lab1, lab2, kL, kC, kH);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDeltaE")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        [return: MarshalAs(UnmanagedType.R8)]
+        private static partial double DeltaE_Internal(
+            in CIELab lab1,
+            in CIELab lab2);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDeltaE", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.R8)]
         private static extern double DeltaE_Internal(
             in CIELab lab1,
             in CIELab lab2);
+#endif
 
         internal static double DeltaE(in CIELab lab1, in CIELab lab2)
         {
             return DeltaE_Internal(lab1, lab2);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCMCdeltaE")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        [return: MarshalAs(UnmanagedType.R8)]
+        private static partial double CMCdeltaE_Internal(
+            in CIELab lab1,
+            in CIELab lab2,
+            [MarshalAs(UnmanagedType.R8)] double l,
+            [MarshalAs(UnmanagedType.R8)] double c);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCMCdeltaE", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.R8)]
         private static extern double CMCdeltaE_Internal(
@@ -57,28 +89,47 @@ namespace lcmsNET
             in CIELab lab2,
             [MarshalAs(UnmanagedType.R8)] double l,
             [MarshalAs(UnmanagedType.R8)] double c);
+#endif
 
         internal static double CMCDeltaE(in CIELab lab1, in CIELab lab2, double l, double c)
         {
             return CMCdeltaE_Internal(lab1, lab2, l, c);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsBFDdeltaE")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        [return: MarshalAs(UnmanagedType.R8)]
+        private static partial double BFDdeltaE_Internal(
+            in CIELab lab1,
+            in CIELab lab2);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBFDdeltaE", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.R8)]
         private static extern double BFDdeltaE_Internal(
             in CIELab lab1,
             in CIELab lab2);
+#endif
 
         internal static double BFDDeltaE(in CIELab lab1, in CIELab lab2)
         {
             return BFDdeltaE_Internal(lab1, lab2);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCIE94DeltaE")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        [return: MarshalAs(UnmanagedType.R8)]
+        private static partial double CIE94DeltaE_Internal(
+            in CIELab lab1,
+            in CIELab lab2);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCIE94DeltaE", CallingConvention = CallingConvention.StdCall)]
         [return: MarshalAs(UnmanagedType.R8)]
         private static extern double CIE94DeltaE_Internal(
             in CIELab lab1,
             in CIELab lab2);
+#endif
 
         internal static double CIE94DeltaE(in CIELab lab1, in CIELab lab2)
         {

--- a/src/lcmsNET/Interop/Interop.Dict.cs
+++ b/src/lcmsNET/Interop/Interop.Dict.cs
@@ -25,32 +25,62 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictAlloc")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DictAlloc_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictAlloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DictAlloc_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr DictAlloc(IntPtr contextID)
         {
             return DictAlloc_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictFree")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void DictFree_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictFree", CallingConvention = CallingConvention.StdCall)]
         private static extern void DictFree_Internal(IntPtr handle);
+#endif
 
         internal static void DictFree(IntPtr handle)
         {
             DictFree_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictDup")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DictDup_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictDup", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DictDup_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DictDup(IntPtr handle)
         {
             return DictDup_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictAddEntry")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int DictAddEntry_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPWStr)] string name,
+                [MarshalAs(UnmanagedType.LPWStr)] string value,
+                IntPtr displayName,
+                IntPtr displayValue);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictAddEntry", CallingConvention = CallingConvention.StdCall)]
         private static extern int DictAddEntry_Internal(
                 IntPtr handle,
@@ -58,24 +88,39 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPWStr)] string value,
                 IntPtr displayName,
                 IntPtr displayValue);
+#endif
 
         internal static int DictAddEntry(IntPtr handle, string name, string value, IntPtr displayName, IntPtr displayValue)
         {
             return DictAddEntry_Internal(handle, name, value, displayName, displayValue);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictGetEntryList")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DictGetEntryList_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictGetEntryList", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DictGetEntryList_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DictGetEntryList(IntPtr handle)
         {
             return DictGetEntryList_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDictNextEntry")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DictNextEntry_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDictNextEntry", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DictNextEntry_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DictNextEntry(IntPtr handle)
         {

--- a/src/lcmsNET/Interop/Interop.GamutBoundaryDescriptor.cs
+++ b/src/lcmsNET/Interop/Interop.GamutBoundaryDescriptor.cs
@@ -25,48 +25,86 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGBDAlloc")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GBDAlloc_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGBDAlloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GBDAlloc_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr GBDAlloc(IntPtr contextID)
         {
             return GBDAlloc_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGBDFree")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void GBDFree_Internal(
+            IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGBDFree", CallingConvention = CallingConvention.StdCall)]
         private static extern void GBDFree_Internal(
             IntPtr handle);
+#endif
 
         internal static void GBDFree(IntPtr handle)
         {
             GBDFree_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGDBAddPoint")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GDBAddPoint_Internal(
+            IntPtr handle,
+            in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGDBAddPoint", CallingConvention = CallingConvention.StdCall)]
         private static extern int GDBAddPoint_Internal(
             IntPtr handle,
             in CIELab lab);
+#endif
 
         internal static int GBDAddPoint(IntPtr handle, in CIELab lab)
         {
             return GDBAddPoint_Internal(handle, lab);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGDBCompute")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GDBCompute_Internal(
+            IntPtr handle,
+            [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGDBCompute", CallingConvention = CallingConvention.StdCall)]
         private static extern int GDBCompute_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static int GBDCompute(IntPtr handle, uint flags)
         {
             return GDBCompute_Internal(handle, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGDBCheckPoint")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GDBCheckPoint_Internal(
+            IntPtr handle,
+            in CIELab lab);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGDBCheckPoint", CallingConvention = CallingConvention.StdCall)]
         private static extern int GDBCheckPoint_Internal(
             IntPtr handle,
             in CIELab lab);
+#endif
 
         internal static int GBDCheckPoint(IntPtr handle, in CIELab lab)
         {

--- a/src/lcmsNET/Interop/Interop.IOHandler.cs
+++ b/src/lcmsNET/Interop/Interop.IOHandler.cs
@@ -26,11 +26,20 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenIOhandlerFromFile_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.LPStr)] string filename,
+                [MarshalAs(UnmanagedType.LPStr)] string access);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromFile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenIOhandlerFromFile_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.LPStr)] string filename,
                 [MarshalAs(UnmanagedType.LPStr)] string access);
+#endif
 
         internal static IntPtr OpenIOHandler(IntPtr contextID, string filepath, string access)
         {
@@ -40,118 +49,212 @@ namespace lcmsNET
             return OpenIOhandlerFromFile_Internal(contextID, filepath, access);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromMem")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenIOhandlerFromMem_Internal(
+                IntPtr contextID,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint size,
+                [MarshalAs(UnmanagedType.LPStr)] string access);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromMem", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenIOhandlerFromMem_Internal(
                 IntPtr contextID,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint size,
                 [MarshalAs(UnmanagedType.LPStr)] string access);
+#endif
 
         internal static IntPtr OpenIOHandler(IntPtr contextID, IntPtr buffer, uint bufferSize, string access)
         {
             return OpenIOhandlerFromMem_Internal(contextID, buffer, bufferSize, access);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromNULL")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenIOhandlerFromNull_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenIOhandlerFromNULL", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenIOhandlerFromNull_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr OpenIOHandler(IntPtr contextID)
         {
             return OpenIOhandlerFromNull_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCloseIOhandler")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int CloseIOhandler_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCloseIOhandler", CallingConvention = CallingConvention.StdCall)]
         private static extern int CloseIOhandler_Internal(IntPtr handle);
+#endif
 
         internal static int CloseIOHandler(IntPtr handle)
         {
             return CloseIOhandler_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetProfileIOhandler")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GetProfileIOHandler_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetProfileIOhandler", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetProfileIOHandler_Internal(IntPtr handle);
+#endif
 
         internal static IntPtr GetProfileIOHandler(IntPtr handle)
         {
             return GetProfileIOHandler_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadUInt8Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadUint8Number_Internal(
+                IntPtr handle,
+                ref byte n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadUInt8Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadUint8Number_Internal(
                 IntPtr handle,
                 ref byte n);
+#endif
 
         internal static bool ReadUint8(IntPtr handle, ref byte n)
         {
             return ReadUint8Number_Internal(handle, ref n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadUInt16Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadUint16Number_Internal(
+                IntPtr handle,
+                ref ushort n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadUInt16Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadUint16Number_Internal(
                 IntPtr handle,
                 ref ushort n);
+#endif
 
         internal static bool ReadUint16(IntPtr handle, ref ushort n)
         {
             return ReadUint16Number_Internal(handle, ref n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadUInt32Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadUint32Number_Internal(
+                IntPtr handle,
+                ref uint n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadUInt32Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadUint32Number_Internal(
                 IntPtr handle,
                 ref uint n);
+#endif
 
         internal static bool ReadUint32(IntPtr handle, ref uint n)
         {
             return ReadUint32Number_Internal(handle, ref n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadUInt64Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadUint64Number_Internal(
+                IntPtr handle,
+                ref ulong n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadUInt64Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadUint64Number_Internal(
                 IntPtr handle,
                 ref ulong n);
+#endif
 
         internal static bool ReadUint64(IntPtr handle, ref ulong n)
         {
             return ReadUint64Number_Internal(handle, ref n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadFloat32Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadFloat32Number_Internal(
+                IntPtr handle,
+                ref float f);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadFloat32Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadFloat32Number_Internal(
                 IntPtr handle,
                 ref float f);
+#endif
 
         internal static bool ReadFloat(IntPtr handle, ref float f)
         {
             return ReadFloat32Number_Internal(handle, ref f) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsRead15Fixed16Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int Read15Fixed16Number_Internal(
+                IntPtr handle,
+                ref double d);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsRead15Fixed16Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int Read15Fixed16Number_Internal(
                 IntPtr handle,
                 ref double d);
+#endif
 
         internal static bool Read15Fixed16(IntPtr handle, ref double d)
         {
             return Read15Fixed16Number_Internal(handle, ref d) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadXYZNumber")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadXYZNumber_Internal(
+                IntPtr handle,
+                ref CIEXYZ xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadXYZNumber", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadXYZNumber_Internal(
                 IntPtr handle,
                 ref CIEXYZ xyz);
+#endif
 
         internal static bool ReadXYZ(IntPtr handle, ref CIEXYZ xyz)
         {
             return ReadXYZNumber_Internal(handle, ref xyz) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadUInt16Array")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int ReadUint16Array_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint n,
+                void* array);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadUInt16Array", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int ReadUint16Array_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint n,
                 void* array);
+#endif
 
         internal unsafe static bool ReadUint16Array(IntPtr handle, ushort[] array)
         {
@@ -162,40 +265,72 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteUInt8Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteUint8Number_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U1)] byte n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteUInt8Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteUint8Number_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U1)] byte n);
+#endif
 
         internal static bool WriteUint8(IntPtr handle, byte n)
         {
             return WriteUint8Number_Internal(handle, n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteUInt16Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteUint16Number_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U2)] ushort n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteUInt16Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteUint16Number_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U2)] ushort n);
+#endif
 
         internal static bool WriteUint16(IntPtr handle, ushort n)
         {
             return WriteUint16Number_Internal(handle, n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteUInt32Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteUint32Number_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteUInt32Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteUint32Number_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint n);
+#endif
 
         internal static bool WriteUint32(IntPtr handle, uint n)
         {
             return WriteUint32Number_Internal(handle, n) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteUInt64Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int WriteUint64Number_Internal(
+                IntPtr handle,
+                /*const*/ ulong* n);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteUInt64Number", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int WriteUint64Number_Internal(
                 IntPtr handle,
                 /*const*/ ulong* n);
+#endif
 
         internal unsafe static bool WriteUint64(IntPtr handle, ulong n)
         {
@@ -206,41 +341,74 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteFloat32Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteFloat32Number_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R4)] float f);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteFloat32Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteFloat32Number_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R4)] float f);
+#endif
 
         internal static bool WriteFloat(IntPtr handle, float f)
         {
             return WriteFloat32Number_Internal(handle, f) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWrite15Fixed16Number")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int Write15Fixed16Number_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R8)] double d);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWrite15Fixed16Number", CallingConvention = CallingConvention.StdCall)]
         private static extern int Write15Fixed16Number_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double d);
+#endif
 
         internal static bool Write15Fixed16(IntPtr handle, double d)
         {
             return Write15Fixed16Number_Internal(handle, d) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteXYZNumber")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteXYZNumber_Internal(
+                IntPtr handle,
+                CIEXYZ xyz);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteXYZNumber", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteXYZNumber_Internal(
                 IntPtr handle,
                 CIEXYZ xyz);
+#endif
 
         internal static bool WriteXYZ(IntPtr handle, CIEXYZ xyz)
         {
             return WriteXYZNumber_Internal(handle, xyz) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteUInt16Array")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int WriteUint16Array_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint n,
+                /*const*/ void* array);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteUInt16Array", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int WriteUint16Array_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint n,
                 /*const*/ void* array);
+#endif
 
         internal unsafe static bool WriteUint16Array(IntPtr handle, ushort[] array)
         {
@@ -251,37 +419,66 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadAlignment")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ReadAlignment_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadAlignment", CallingConvention = CallingConvention.StdCall)]
         private static extern int ReadAlignment_Internal(
                 IntPtr handle);
+#endif
 
         internal static bool ReadAlignment(IntPtr handle)
         {
             return ReadAlignment_Internal(handle) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteAlignment")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteAlignment_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteAlignment", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteAlignment_Internal(
                 IntPtr handle);
+#endif
 
         internal static bool WriteAlignment(IntPtr handle)
         {
             return WriteAlignment_Internal(handle) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsReadTypeBase")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint ReadTypeBase_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsReadTypeBase", CallingConvention = CallingConvention.StdCall)]
         private static extern uint ReadTypeBase_Internal(
                 IntPtr handle);
+#endif
 
         internal static uint ReadTypeBase(IntPtr handle)
         {
             return ReadTypeBase_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsWriteTypeBase")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteTypeBase_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint sig);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsWriteTypeBase", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteTypeBase_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint sig);
+#endif
 
         internal static bool WriteTypeBase(IntPtr handle, uint sig)
         {

--- a/src/lcmsNET/Interop/Interop.IT8.cs
+++ b/src/lcmsNET/Interop/Interop.IT8.cs
@@ -364,7 +364,7 @@ namespace lcmsNET
             return IT8SetDataDbl_Internal(handle, patch, sample, value);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8FindDataFormat")]
         private unsafe static partial int IT8FindDataFormat_Internal(
             IntPtr handle,
@@ -381,7 +381,7 @@ namespace lcmsNET
             return IT8FindDataFormat_Internal(handle, sample);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataFormat")]
         private unsafe static partial int IT8SetDataFormat_Internal(
             IntPtr handle,
@@ -400,7 +400,7 @@ namespace lcmsNET
             return IT8SetDataFormat_Internal(handle, column, sample);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8EnumDataFormat")]
         private unsafe static partial int IT8EnumDataFormat_Internal(
                 IntPtr handle,
@@ -426,7 +426,7 @@ namespace lcmsNET
             return samples;
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetPatchName")]
         private unsafe static partial IntPtr IT8GetPatchName_Internal(
                 IntPtr handle,
@@ -446,7 +446,7 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8DefineDblFormat")]
         private unsafe static partial void IT8DefineDblFormat_Internal(
             IntPtr handle,

--- a/src/lcmsNET/Interop/Interop.IT8.cs
+++ b/src/lcmsNET/Interop/Interop.IT8.cs
@@ -364,31 +364,53 @@ namespace lcmsNET
             return IT8SetDataDbl_Internal(handle, patch, sample, value);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8FindDataFormat")]
+        private unsafe static partial int IT8FindDataFormat_Internal(
+            IntPtr handle,
+            [MarshalAs(UnmanagedType.LPStr)] string sample);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8FindDataFormat", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int IT8FindDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
+#endif
 
         internal static int IT8FindDataFormat(IntPtr handle, string sample)
         {
             return IT8FindDataFormat_Internal(handle, sample);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataFormat")]
+        private unsafe static partial int IT8SetDataFormat_Internal(
+            IntPtr handle,
+            [MarshalAs(UnmanagedType.I4)] int n,
+            [MarshalAs(UnmanagedType.LPStr)] string sample);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataFormat", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int IT8SetDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.I4)] int n,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
+#endif
 
         internal static int IT8SetDataFormat(IntPtr handle, int column, string sample)
         {
             return IT8SetDataFormat_Internal(handle, column, sample);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8EnumDataFormat")]
+        private unsafe static partial int IT8EnumDataFormat_Internal(
+                IntPtr handle,
+                out IntPtr sampleNames);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8EnumDataFormat", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int IT8EnumDataFormat_Internal(
                 IntPtr handle,
                 out IntPtr sampleNames);
+#endif
 
         internal unsafe static string[] IT8EnumDataFormat(IntPtr handle)
         {
@@ -404,11 +426,19 @@ namespace lcmsNET
             return samples;
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetPatchName")]
+        private unsafe static partial IntPtr IT8GetPatchName_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int nPatch,
+                [MarshalAs(UnmanagedType.LPStr)] string sample);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8GetPatchName", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern IntPtr IT8GetPatchName_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nPatch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample);
+#endif
 
         internal static string IT8GetPatchName(IntPtr handle, int nPatch)
         {
@@ -416,10 +446,17 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8DefineDblFormat")]
+        private unsafe static partial void IT8DefineDblFormat_Internal(
+            IntPtr handle,
+            [MarshalAs(UnmanagedType.LPStr)] string format);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8DefineDblFormat", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void IT8DefineDblFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string format);
+#endif
 
         internal static void IT8DefineDblFormat(IntPtr handle, string format)
         {

--- a/src/lcmsNET/Interop/Interop.IT8.cs
+++ b/src/lcmsNET/Interop/Interop.IT8.cs
@@ -26,45 +26,80 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8Alloc")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr IT8Alloc_Internal(
+            IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8Alloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr IT8Alloc_Internal(
             IntPtr contextID);
+#endif
 
         internal static IntPtr IT8Alloc(IntPtr contextID)
         {
             return IT8Alloc_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8Free")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void IT8Free_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8Free", CallingConvention = CallingConvention.StdCall)]
         private static extern void IT8Free_Internal(IntPtr handle);
+#endif
 
         internal static void IT8Free(IntPtr handle)
         {
             IT8Free_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8TableCount")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint IT8TableCount_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8TableCount", CallingConvention = CallingConvention.StdCall)]
         private static extern uint IT8TableCount_Internal(IntPtr handle);
+#endif
 
         internal static uint IT8TableCount(IntPtr handle)
         {
             return IT8TableCount_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetTable")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IT8SetTable_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint nTable);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8SetTable", CallingConvention = CallingConvention.StdCall)]
         private static extern int IT8SetTable_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint nTable);
+#endif
 
         internal static int IT8SetTable(IntPtr handle, uint nTable)
         {
             return IT8SetTable_Internal(handle, nTable);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8LoadFromFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr IT8LoadFromFile_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.LPStr)] string filename);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8LoadFromFile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr IT8LoadFromFile_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.LPStr)] string filename);
+#endif
 
         internal static IntPtr IT8LoadFromFile(IntPtr contextID, string filepath)
         {
@@ -73,24 +108,41 @@ namespace lcmsNET
             return IT8LoadFromFile_Internal(contextID, filepath);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8LoadFromMem", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8LoadFromMem_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8LoadFromMem")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8LoadFromMem_Internal(
                 IntPtr contextID,
                 /*const*/ void* memPtr,
-                [MarshalAs(UnmanagedType.U4)] int memSize);
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8LoadFromMem", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern IntPtr IT8LoadFromMem_Internal(
+                IntPtr contextID,
+                /*const*/ void* memPtr,
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#endif
 
-        internal unsafe static IntPtr IT8LoadFromMem(IntPtr contextID, byte[] memory)
+        internal static unsafe IntPtr IT8LoadFromMem(IntPtr contextID, byte[] memory)
         {
             fixed (void* memPtr = &memory[0])
             {
-                return IT8LoadFromMem_Internal(contextID, memPtr, memory.Length);
+                return IT8LoadFromMem_Internal(contextID, memPtr, (uint)memory.Length);
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SaveToFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IT8SaveToFile_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string filename);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIT8SaveToFile", CallingConvention = CallingConvention.StdCall)]
         private static extern int IT8SaveToFile_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string filename);
+#endif
 
         internal static int IT8SaveToFile(IntPtr handle, string filepath)
         {
@@ -99,13 +151,22 @@ namespace lcmsNET
             return IT8SaveToFile_Internal(handle, filepath);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SaveToMem", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SaveToMem_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SaveToMem")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SaveToMem_Internal(
                 IntPtr handle,
                 void* memPtr,
                 uint* bytesNeeded);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SaveToMem", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SaveToMem_Internal(
+                IntPtr handle,
+                void* memPtr,
+                uint* bytesNeeded);
+#endif
 
-        internal unsafe static int IT8SaveToMem(IntPtr handle, byte[] memPtr, out uint bytesNeeded)
+        internal static unsafe int IT8SaveToMem(IntPtr handle, byte[] memPtr, out uint bytesNeeded)
         {
             int result = 0;
             uint n = (uint)(memPtr?.Length ?? 0);
@@ -124,9 +185,16 @@ namespace lcmsNET
             return result;
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetSheetType", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8GetSheetType_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetSheetType")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8GetSheetType_Internal(
                 IntPtr handle);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetSheetType", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern IntPtr IT8GetSheetType_Internal(
+                IntPtr handle);
+#endif
 
         internal static string IT8GetSheetType(IntPtr handle)
         {
@@ -134,30 +202,54 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetSheetType", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetSheetType_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetSheetType")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetSheetType_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string sheetType);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetSheetType", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetSheetType_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string sheetType);
+#endif
 
         internal static int IT8SetSheetType(IntPtr handle, string sheetType)
         {
             return IT8SetSheetType_Internal(handle, sheetType);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetComment", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetComment_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetComment")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetComment_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string comment);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetComment", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetComment_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string comment);
+#endif
 
         internal static int IT8SetComment(IntPtr handle, string comment)
         {
             return IT8SetComment_Internal(handle, comment);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetProperty", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8GetProperty_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetProperty")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8GetProperty_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string propertyName);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetProperty", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern IntPtr IT8GetProperty_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string propertyName);
+#endif
 
         internal static string IT8GetProperty(IntPtr handle, string propertyName)
         {
@@ -165,78 +257,140 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyStr", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetPropertyStr_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetPropertyStr")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetPropertyStr_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 [MarshalAs(UnmanagedType.LPStr)] string value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyStr", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetPropertyStr_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                [MarshalAs(UnmanagedType.LPStr)] string value);
+#endif
 
         internal static int IT8SetProperty(IntPtr handle, string name, string value)
         {
             return IT8SetPropertyStr_Internal(handle, name, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetPropertyDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern double IT8GetPropertyDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetPropertyDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial double IT8GetPropertyDbl_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string propertyName);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetPropertyDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern double IT8GetPropertyDbl_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string propertyName);
+#endif
 
         internal static double IT8GetPropertyDouble(IntPtr handle, string propertyName)
         {
             return IT8GetPropertyDbl_Internal(handle, propertyName);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetPropertyDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetPropertyDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetPropertyDbl_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 [MarshalAs(UnmanagedType.R8)] double value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetPropertyDbl_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                [MarshalAs(UnmanagedType.R8)] double value);
+#endif
 
         internal static int IT8SetPropertyDouble(IntPtr handle, string name, double value)
         {
             return IT8SetPropertyDbl_Internal(handle, name, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyHex", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetPropertyHex_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetPropertyHex")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetPropertyHex_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 [MarshalAs(UnmanagedType.U4)] uint value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyHex", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetPropertyHex_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                [MarshalAs(UnmanagedType.U4)] uint value);
+#endif
 
         internal static int IT8SetPropertyHex(IntPtr handle, string name, uint value)
         {
             return IT8SetPropertyHex_Internal(handle, name, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyUncooked", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetPropertyUncooked_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetPropertyUncooked")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetPropertyUncooked_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 [MarshalAs(UnmanagedType.LPStr)] string value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyUncooked", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetPropertyUncooked_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                [MarshalAs(UnmanagedType.LPStr)] string value);
+#endif
 
         internal static int IT8SetPropertyUncooked(IntPtr handle, string name, string value)
         {
             return IT8SetPropertyUncooked_Internal(handle, name, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyMulti", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetPropertyMulti_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetPropertyMulti")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetPropertyMulti_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string key,
                 [MarshalAs(UnmanagedType.LPStr)] string subkey,
                 [MarshalAs(UnmanagedType.LPStr)] string value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetPropertyMulti", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetPropertyMulti_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string key,
+                [MarshalAs(UnmanagedType.LPStr)] string subkey,
+                [MarshalAs(UnmanagedType.LPStr)] string value);
+#endif
 
         internal static int IT8SetProperty(IntPtr handle, string key, string subkey, string value)
         {
             return IT8SetPropertyMulti_Internal(handle, key, subkey, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8EnumProperties", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern uint IT8EnumProperties_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8EnumProperties")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial uint IT8EnumProperties_Internal(
                 IntPtr handle,
                 out IntPtr propertyNames);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8EnumProperties", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern uint IT8EnumProperties_Internal(
+                IntPtr handle,
+                out IntPtr propertyNames);
+#endif
 
-        internal unsafe static string[] IT8EnumProperties(IntPtr handle)
+        internal static unsafe string[] IT8EnumProperties(IntPtr handle)
         {
             uint count = IT8EnumProperties_Internal(handle, out IntPtr propertyNames);
             string[] properties = new string[count];
@@ -250,13 +404,22 @@ namespace lcmsNET
             return properties;
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8EnumPropertyMulti", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern uint IT8EnumPropertyMulti_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8EnumPropertyMulti")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial uint IT8EnumPropertyMulti_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string key,
                 out IntPtr subPropertyNames);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8EnumPropertyMulti", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern uint IT8EnumPropertyMulti_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string key,
+                out IntPtr subPropertyNames);
+#endif
 
-        internal unsafe static string[] IT8EnumPropertyMulti(IntPtr handle, string key)
+        internal static unsafe string[] IT8EnumPropertyMulti(IntPtr handle, string key)
         {
             uint count = IT8EnumPropertyMulti_Internal(handle, key, out IntPtr subPropertyNames);
             string[] properties = new string[count];
@@ -270,11 +433,20 @@ namespace lcmsNET
             return properties;
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataRowCol", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8GetDataRowCol_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetDataRowCol")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8GetDataRowCol_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int row,
                 [MarshalAs(UnmanagedType.I4)] int col);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataRowCol", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern IntPtr IT8GetDataRowCol_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int row,
+                [MarshalAs(UnmanagedType.I4)] int col);
+#endif
 
         internal static string IT8GetDataRowCol(IntPtr handle, int row, int column)
         {
@@ -282,11 +454,20 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetData", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8GetData_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetData")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8GetData_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string patch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetData", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern IntPtr IT8GetData_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string patch,
+                [MarshalAs(UnmanagedType.LPStr)] string sample);
+#endif
 
         internal static string IT8GetData(IntPtr handle, string patch, string sample)
         {
@@ -294,70 +475,128 @@ namespace lcmsNET
             return Marshal.PtrToStringAnsi(ptr);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataRowColDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern double IT8GetDataRowColDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetDataRowColDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial double IT8GetDataRowColDbl_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int row,
                 [MarshalAs(UnmanagedType.I4)] int col);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataRowColDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern double IT8GetDataRowColDbl_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int row,
+                [MarshalAs(UnmanagedType.I4)] int col);
+#endif
 
         internal static double IT8GetDataRowColDouble(IntPtr handle, int row, int column)
         {
             return IT8GetDataRowColDbl_Internal(handle, row, column);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern double IT8GetDataDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetDataDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial double IT8GetDataDbl_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string patch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8GetDataDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern double IT8GetDataDbl_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string patch,
+                [MarshalAs(UnmanagedType.LPStr)] string sample);
+#endif
 
         internal static double IT8GetDataDbl(IntPtr handle, string patch, string sample)
         {
             return IT8GetDataDbl_Internal(handle, patch, sample);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetData", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetData_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetData")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetData_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string patch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample,
                 [MarshalAs(UnmanagedType.LPStr)] string value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetData", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetData_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string patch,
+                [MarshalAs(UnmanagedType.LPStr)] string sample,
+                [MarshalAs(UnmanagedType.LPStr)] string value);
+#endif
 
         internal static int IT8SetData(IntPtr handle, string patch, string sample, string value)
         {
             return IT8SetData_Internal(handle, patch, sample, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataRowCol", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetDataRowCol_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataRowCol")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetDataRowCol_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int row,
                 [MarshalAs(UnmanagedType.I4)] int col,
                 [MarshalAs(UnmanagedType.LPStr)] string value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataRowCol", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetDataRowCol_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int row,
+                [MarshalAs(UnmanagedType.I4)] int col,
+                [MarshalAs(UnmanagedType.LPStr)] string value);
+#endif
 
         internal static int IT8SetDataRowCol(IntPtr handle, int row, int column, string value)
         {
             return IT8SetDataRowCol_Internal(handle, row, column, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataRowColDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetDataRowColDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataRowColDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetDataRowColDbl_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.I4)] int row,
             [MarshalAs(UnmanagedType.I4)] int col,
             [MarshalAs(UnmanagedType.R8)] double value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataRowColDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetDataRowColDbl_Internal(
+            IntPtr handle,
+            [MarshalAs(UnmanagedType.I4)] int row,
+            [MarshalAs(UnmanagedType.I4)] int col,
+            [MarshalAs(UnmanagedType.R8)] double value);
+#endif
 
         internal static int IT8SetDataRowColDbl(IntPtr handle, int row, int column, double value)
         {
             return IT8SetDataRowColDbl_Internal(handle, row, column, value);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataDbl", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetDataDbl_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataDbl")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetDataDbl_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string patch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample,
                 [MarshalAs(UnmanagedType.R8)] double value);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataDbl", CallingConvention = CallingConvention.StdCall)]
+        private static unsafe extern int IT8SetDataDbl_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string patch,
+                [MarshalAs(UnmanagedType.LPStr)] string sample,
+                [MarshalAs(UnmanagedType.R8)] double value);
+#endif
 
         internal static int IT8SetDataDbl(IntPtr handle, string patch, string sample, double value)
         {
@@ -366,12 +605,13 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8FindDataFormat")]
-        private unsafe static partial int IT8FindDataFormat_Internal(
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8FindDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsIT8FindDataFormat", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8FindDataFormat_Internal(
+        private static unsafe extern int IT8FindDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
 #endif
@@ -383,13 +623,14 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8SetDataFormat")]
-        private unsafe static partial int IT8SetDataFormat_Internal(
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8SetDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.I4)] int n,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsIT8SetDataFormat", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8SetDataFormat_Internal(
+        private static unsafe extern int IT8SetDataFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.I4)] int n,
             [MarshalAs(UnmanagedType.LPStr)] string sample);
@@ -402,17 +643,18 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8EnumDataFormat")]
-        private unsafe static partial int IT8EnumDataFormat_Internal(
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int IT8EnumDataFormat_Internal(
                 IntPtr handle,
                 out IntPtr sampleNames);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsIT8EnumDataFormat", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern int IT8EnumDataFormat_Internal(
+        private static unsafe extern int IT8EnumDataFormat_Internal(
                 IntPtr handle,
                 out IntPtr sampleNames);
 #endif
 
-        internal unsafe static string[] IT8EnumDataFormat(IntPtr handle)
+        internal static unsafe string[] IT8EnumDataFormat(IntPtr handle)
         {
             int count = IT8EnumDataFormat_Internal(handle, out IntPtr sampleNames);
             string[] samples = new string[count];
@@ -428,13 +670,14 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8GetPatchName")]
-        private unsafe static partial IntPtr IT8GetPatchName_Internal(
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr IT8GetPatchName_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nPatch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsIT8GetPatchName", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern IntPtr IT8GetPatchName_Internal(
+        private static unsafe extern IntPtr IT8GetPatchName_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nPatch,
                 [MarshalAs(UnmanagedType.LPStr)] string sample);
@@ -448,12 +691,13 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIT8DefineDblFormat")]
-        private unsafe static partial void IT8DefineDblFormat_Internal(
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial void IT8DefineDblFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string format);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsIT8DefineDblFormat", CallingConvention = CallingConvention.StdCall)]
-        private unsafe static extern void IT8DefineDblFormat_Internal(
+        private static unsafe extern void IT8DefineDblFormat_Internal(
             IntPtr handle,
             [MarshalAs(UnmanagedType.LPStr)] string format);
 #endif

--- a/src/lcmsNET/Interop/Interop.MultiLocalizedUnicode.cs
+++ b/src/lcmsNET/Interop/Interop.MultiLocalizedUnicode.cs
@@ -27,39 +27,70 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUalloc")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr MLUalloc_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nItems);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUalloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr MLUalloc_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint nItems);
+#endif
 
         internal static IntPtr MLUAlloc(IntPtr contextID, uint nItems)
         {
             return MLUalloc_Internal(contextID, nItems);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUfree")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void MLUfree_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUfree", CallingConvention = CallingConvention.StdCall)]
         private static extern void MLUfree_Internal(IntPtr handle);
+#endif
 
         internal static void MLUFree(IntPtr handle)
         {
             MLUfree_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUdup")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr MLUdup_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUdup", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr MLUdup_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr MLUDup(IntPtr handle)
         {
             return MLUdup_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUsetASCII")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MLUsetASCII_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                [MarshalAs(UnmanagedType.LPStr)] string asciiString);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUsetASCII", CallingConvention = CallingConvention.StdCall)]
         private static extern int MLUsetASCII_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] languageCode,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 [MarshalAs(UnmanagedType.LPStr)] string asciiString);
+#endif
 
         internal static int MLUSetAscii(IntPtr handle, string languageCode, string countryCode, string value)
         {
@@ -69,12 +100,22 @@ namespace lcmsNET
             return MLUsetASCII_Internal(handle, language, country, value);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUsetWide")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MLUsetWide_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                [MarshalAs(UnmanagedType.LPWStr)] string wideString);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUsetWide", CallingConvention = CallingConvention.StdCall)]
         private static extern int MLUsetWide_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] languageCode,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 [MarshalAs(UnmanagedType.LPWStr)] string wideString);
+#endif
 
         internal static int MLUSetWide(IntPtr handle, string languageCode, string countryCode, string value)
         {
@@ -85,12 +126,22 @@ namespace lcmsNET
         }
 
 #if NET5_0_OR_GREATER
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUsetUTF8")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MLUsetUTF8_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8String);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUsetUTF8", CallingConvention = CallingConvention.StdCall)]
         private static extern int MLUsetUTF8_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] languageCode,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 [MarshalAs(UnmanagedType.LPUTF8Str)] string utf8String);
+#endif
 
         internal static int MLUSetUTF8(IntPtr handle, string languageCode, string countryCode, string value)
         {
@@ -101,6 +152,16 @@ namespace lcmsNET
         }
 #endif
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUgetASCII")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint MLUgetASCII_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUgetASCII", CallingConvention = CallingConvention.StdCall)]
         private static extern uint MLUgetASCII_Internal(
                 IntPtr handle,
@@ -108,6 +169,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static string MLUGetASCII(IntPtr handle, string languageCode, string countryCode)
         {
@@ -121,7 +183,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(Convert.ToInt32(bytes));
             try
             {
-                MLUgetASCII_Internal(handle, language, country, buffer, bytes);
+                _ = MLUgetASCII_Internal(handle, language, country, buffer, bytes);
                 return Marshal.PtrToStringAnsi(buffer);
             }
             finally
@@ -130,6 +192,16 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUgetWide")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint MLUgetWide_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUgetWide", CallingConvention = CallingConvention.StdCall)]
         private static extern uint MLUgetWide_Internal(
                 IntPtr handle,
@@ -137,6 +209,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static string MLUGetWide(IntPtr handle, string languageCode, string countryCode)
         {
@@ -150,7 +223,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(Convert.ToInt32(bytes));
             try
             {
-                MLUgetWide_Internal(handle, language, country, buffer, bytes);
+                _ = MLUgetWide_Internal(handle, language, country, buffer, bytes);
                 return Marshal.PtrToStringUni(buffer);
             }
             finally
@@ -160,6 +233,16 @@ namespace lcmsNET
         }
 
 #if NET5_0_OR_GREATER
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUgetUTF8")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint MLUgetUTF8_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUgetUTF8", CallingConvention = CallingConvention.StdCall)]
         private static extern uint MLUgetUTF8_Internal(
                 IntPtr handle,
@@ -167,6 +250,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static string MLUGetUTF8(IntPtr handle, string languageCode, string countryCode)
         {
@@ -180,7 +264,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(Convert.ToInt32(bytes));
             try
             {
-                MLUgetUTF8_Internal(handle, language, country, buffer, bytes);
+                _ = MLUgetUTF8_Internal(handle, language, country, buffer, bytes);
                 return Marshal.PtrToStringUTF8(buffer);
             }
             finally
@@ -190,6 +274,16 @@ namespace lcmsNET
         }
 #endif
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUgetTranslation")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MLUgetTranslation_Internal(
+                IntPtr handle,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                [Out] byte[] obtainedLanguage,
+                [Out] byte[] obtainedCountry);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUgetTranslation", CallingConvention = CallingConvention.StdCall)]
         private static extern int MLUgetTranslation_Internal(
                 IntPtr handle,
@@ -197,21 +291,27 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] obtainedLanguage,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] obtainedCountry);
+#endif
 
         internal static int MLUGetTranslation(IntPtr handle, string languageCode, string countryCode,
                 out string translationLanguage, out string translationCountry)
         {
             byte[] language = Helper.ToASCIIBytes(languageCode);
             byte[] country = Helper.ToASCIIBytes(countryCode);
-            byte[] obtainedLanguage = new byte[3] { 0, 0, 0 };
-            byte[] obtainedCountry = new byte[3] { 0, 0, 0 };
+            byte[] obtainedLanguage = [0, 0, 0];
+            byte[] obtainedCountry = [0, 0, 0];
 
             int result = MLUgetTranslation_Internal(handle, language, country, obtainedLanguage, obtainedCountry);
             if (result != 0)
             {
                 // remove any single trailing null character
+#if NET5_0_OR_GREATER
+                translationLanguage = MatchSingleTrailingNull().Replace(Helper.ToString(obtainedLanguage), "");
+                translationCountry = MatchSingleTrailingNull().Replace(Helper.ToString(obtainedCountry), "");
+#else
                 translationLanguage = Regex.Replace(Helper.ToString(obtainedLanguage), "\0$", "");
                 translationCountry = Regex.Replace(Helper.ToString(obtainedCountry), "\0$", "");
+#endif
             }
             else
             {
@@ -220,9 +320,16 @@ namespace lcmsNET
             return result;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUtranslationsCount")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint MLUtranslationsCount_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUtranslationsCount", CallingConvention = CallingConvention.StdCall)]
         private static extern uint MLUtranslationsCount_Internal(
                 IntPtr handle);
+#endif
 
         internal static uint MLUTranslationsCount(IntPtr handle)
         {
@@ -230,24 +337,39 @@ namespace lcmsNET
         }
 
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMLUtranslationsCodes")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MLUtranslationsCodes_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint index,
+                [Out] byte[] languageCode,
+                [Out] byte[] countryCode);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMLUtranslationsCodes", CallingConvention = CallingConvention.StdCall)]
         private static extern int MLUtranslationsCodes_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U4)] uint index,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] languageCode,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode);
+#endif
 
         internal static int MLUTranslationsCodes(IntPtr handle, uint index, out string languageCode, out string countryCode)
         {
-            byte[] language = new byte[3] { 0, 0, 0 };
-            byte[] country = new byte[3] { 0, 0, 0 };
+            byte[] language = [0, 0, 0];
+            byte[] country = [0, 0, 0];
 
             int result = MLUtranslationsCodes_Internal(handle, index, language, country);
             if (result != 0)
             {
                 // remove any single trailing null character
+#if NET5_0_OR_GREATER
+                languageCode = MatchSingleTrailingNull().Replace(Helper.ToString(language), "");
+                countryCode = MatchSingleTrailingNull().Replace(Helper.ToString(country), "");
+#else
                 languageCode = Regex.Replace(Helper.ToString(language), "\0$", "");
                 countryCode = Regex.Replace(Helper.ToString(country), "\0$", "");
+#endif
             }
             else
             {
@@ -255,5 +377,10 @@ namespace lcmsNET
             }
             return result;
         }
+
+#if NET5_0_OR_GREATER
+        [GeneratedRegex("\0$")]
+        private static partial Regex MatchSingleTrailingNull();
+#endif
     }
 }

--- a/src/lcmsNET/Interop/Interop.NamedColorList.cs
+++ b/src/lcmsNET/Interop/Interop.NamedColorList.cs
@@ -25,6 +25,16 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsAllocNamedColorList")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr AllocNamedColorList_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint n,
+                [MarshalAs(UnmanagedType.U4)] uint colorantCount,
+                [MarshalAs(UnmanagedType.LPStr)] string prefix,
+                [MarshalAs(UnmanagedType.LPStr)] string suffix);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsAllocNamedColorList", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr AllocNamedColorList_Internal(
                 IntPtr contextID,
@@ -32,69 +42,127 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint colorantCount,
                 [MarshalAs(UnmanagedType.LPStr)] string prefix,
                 [MarshalAs(UnmanagedType.LPStr)] string suffix);
+#endif
 
         internal static IntPtr AllocNamedColorList(IntPtr contextID, uint n, uint colorantCount, string prefix, string suffix)
         {
             return AllocNamedColorList_Internal(contextID, n, colorantCount, prefix, suffix);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsFreeNamedColorList")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void FreeNamedColorList_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFreeNamedColorList", CallingConvention = CallingConvention.StdCall)]
         private static extern void FreeNamedColorList_Internal(IntPtr handle);
+#endif
 
         internal static void FreeNamedColorList(IntPtr handle)
         {
             FreeNamedColorList_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDupNamedColorList")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DupNamedColorList_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDupNamedColorList", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DupNamedColorList_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DupNamedColorList(IntPtr handle)
         {
             return DupNamedColorList_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetNamedColorList")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GetNamedColorList_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetNamedColorList", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetNamedColorList_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr GetNamedColorList(IntPtr handle)
         {
             return GetNamedColorList_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsAppendNamedColor")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int AppendNamedColor_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name,
+                [In] ushort[] pcs,
+                [In] ushort[] colorant);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsAppendNamedColor", CallingConvention = CallingConvention.StdCall)]
         private static extern int AppendNamedColor_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] ushort[] pcs,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] colorant);
+#endif
 
         internal static int AppendNamedColor(IntPtr handle, string name, ushort[] pcs, ushort[] colorant)
         {
             return AppendNamedColor_Internal(handle, name, pcs, colorant);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsNamedColorCount")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint NamedColorCount_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsNamedColorCount", CallingConvention = CallingConvention.StdCall)]
         private static extern uint NamedColorCount_Internal(
                 IntPtr handle);
+#endif
 
         internal static uint NamedColorCount(IntPtr handle)
         {
             return NamedColorCount_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsNamedColorIndex")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int NamedColorIndex_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string name);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsNamedColorIndex", CallingConvention = CallingConvention.StdCall)]
         private static extern int NamedColorIndex_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string name);
+#endif
 
         internal static int NamedColorIndex(IntPtr handle, string name)
         {
             return NamedColorIndex_Internal(handle, name);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsNamedColorInfo")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int NamedColorInfo_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint nColor,
+                IntPtr name,
+                IntPtr prefix,
+                IntPtr suffix,
+                [Out] ushort[] pcs,
+                [Out] ushort[] colorant);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsNamedColorInfo", CallingConvention = CallingConvention.StdCall)]
         private static extern int NamedColorInfo_Internal(
                 IntPtr handle,
@@ -104,6 +172,7 @@ namespace lcmsNET
                 IntPtr suffix,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 3)] ushort[] pcs,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] colorant);
+#endif
 
         internal static int NamedColorInfo(IntPtr handle, uint nColor, out string name, out string prefix,
                 out string suffix, ushort[] pcs, ushort[] colorant)

--- a/src/lcmsNET/Interop/Interop.Pipeline.cs
+++ b/src/lcmsNET/Interop/Interop.Pipeline.cs
@@ -25,7 +25,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineAlloc")]
         private static partial IntPtr PipelineAlloc_Internal(
                 IntPtr contextID,
@@ -44,7 +44,7 @@ namespace lcmsNET
             return PipelineAlloc_Internal(contextID, inputChannels, outputChannels);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineFree")]
         private static partial void PipelineFree_Internal(IntPtr handle);
 #else
@@ -57,7 +57,7 @@ namespace lcmsNET
             PipelineFree_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineDup")]
         private static partial IntPtr PipelineDup_Internal(
                 IntPtr handle);
@@ -72,7 +72,7 @@ namespace lcmsNET
             return PipelineDup_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineCat")]
         private static partial int PipelineCat_Internal(
                 IntPtr handle,
@@ -89,7 +89,7 @@ namespace lcmsNET
             return PipelineCat_Internal(handle, other);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEvalFloat")]
         private static partial void PipelineEvalFloat_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
@@ -108,7 +108,7 @@ namespace lcmsNET
             PipelineEvalFloat_Internal(vIn, vOut, handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEvalReverseFloat")]
         private static partial int PipelineEvalReverseFloat_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
@@ -129,7 +129,7 @@ namespace lcmsNET
             return PipelineEvalReverseFloat_Internal(vIn, vOut, hint, handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEval16")]
         private static partial void PipelineEval16_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] vIn,
@@ -148,7 +148,7 @@ namespace lcmsNET
             PipelineEval16_Internal(vIn, vOut, handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineInsertStage")]
         private static partial int PipelineInsertStage_Internal(
                 IntPtr handle,
@@ -167,7 +167,7 @@ namespace lcmsNET
             return PipelineInsertStage_Internal(handle, location, stage);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineInputChannels")]
         private static partial uint PipelineInputChannels_Internal(IntPtr handle);
 #else
@@ -180,7 +180,7 @@ namespace lcmsNET
             return PipelineInputChannels_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineOutputChannels")]
         private static partial uint PipelineOutputChannels_Internal(IntPtr handle);
 #else
@@ -193,7 +193,7 @@ namespace lcmsNET
             return PipelineOutputChannels_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineStageCount")]
         private static partial uint PipelineStageCount_Internal(IntPtr handle);
 #else
@@ -206,7 +206,7 @@ namespace lcmsNET
             return PipelineStageCount_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineUnlinkStage")]
         private static partial void PipelineUnlinkStage_Internal(
                 IntPtr handle,
@@ -231,7 +231,7 @@ namespace lcmsNET
             PipelineUnlinkStage_Internal(handle, location, ref stage);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToFirstStage")]
         private static partial IntPtr PipelineGetPtrToFirstStage_Internal(IntPtr handle);
 #else
@@ -244,7 +244,7 @@ namespace lcmsNET
             return PipelineGetPtrToFirstStage_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToLastStage")]
         private static partial IntPtr PipelineGetPtrToLastStage_Internal(IntPtr handle);
 #else
@@ -257,7 +257,7 @@ namespace lcmsNET
             return PipelineGetPtrToLastStage_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsPipelineSetSaveAs8bitsFlag")]
         private static partial int PipelineSetSaveAs8bitsFlag_Internal(
                 IntPtr handle,
@@ -274,7 +274,7 @@ namespace lcmsNET
             return PipelineSetSaveAs8bitsFlag_Internal(handle, on);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsDefaultICCintents")]
         private static partial IntPtr DefaultICCIntents_Internal(
                 IntPtr contextID,
@@ -302,7 +302,7 @@ namespace lcmsNET
             return DefaultICCIntents_Internal(contextID, (uint)profiles.Length, intents, profiles, bpc, adaptationStates, flags);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsPipelineSetOptimizationParameters")]
         internal static partial void PipelineSetOptimizationParameters_Internal(
                 IntPtr handle,

--- a/src/lcmsNET/Interop/Interop.Pipeline.cs
+++ b/src/lcmsNET/Interop/Interop.Pipeline.cs
@@ -279,10 +279,10 @@ namespace lcmsNET
         private static partial IntPtr DefaultICCIntents_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint nProfiles,
-                uint[] intents,
-                IntPtr[] profiles,
-                int[] bpc,
-                double[] adaptationStates,
+                [In] uint[] intents,
+                [In] IntPtr[] profiles,
+                [In] int[] bpc,
+                [In] double[] adaptationStates,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
 #else
         [DllImport(Liblcms, EntryPoint = "_cmsDefaultICCintents", CallingConvention = CallingConvention.StdCall)]

--- a/src/lcmsNET/Interop/Interop.Pipeline.cs
+++ b/src/lcmsNET/Interop/Interop.Pipeline.cs
@@ -25,118 +25,200 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineAlloc")]
+        private static partial IntPtr PipelineAlloc_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint inputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint outputChannels);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineAlloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr PipelineAlloc_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint inputChannels,
                 [MarshalAs(UnmanagedType.U4)] uint outputChannels);
+#endif
 
         internal static IntPtr PipelineAlloc(IntPtr contextID, uint inputChannels, uint outputChannels)
         {
             return PipelineAlloc_Internal(contextID, inputChannels, outputChannels);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineFree")]
+        private static partial void PipelineFree_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineFree", CallingConvention = CallingConvention.StdCall)]
         private static extern void PipelineFree_Internal(IntPtr handle);
+#endif
 
         internal static void PipelineFree(IntPtr handle)
         {
             PipelineFree_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineDup")]
+        private static partial IntPtr PipelineDup_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineDup", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr PipelineDup_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr PipelineDup(IntPtr handle)
         {
             return PipelineDup_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineCat")]
+        private static partial int PipelineCat_Internal(
+                IntPtr handle,
+                IntPtr other);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineCat", CallingConvention = CallingConvention.StdCall)]
         private static extern int PipelineCat_Internal(
                 IntPtr handle,
                 IntPtr other);
+#endif
 
         internal static int PipelineCat(IntPtr handle, IntPtr other)
         {
             return PipelineCat_Internal(handle, other);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEvalFloat")]
+        private static partial void PipelineEvalFloat_Internal(
+                [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
+                [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vOut,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineEvalFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern void PipelineEvalFloat_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
                 [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vOut,
                 IntPtr handle);
+#endif
 
         internal static void PipelineEvalFloat(IntPtr handle, float[] vIn, float[] vOut)
         {
             PipelineEvalFloat_Internal(vIn, vOut, handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEvalReverseFloat")]
+        private static partial int PipelineEvalReverseFloat_Internal(
+                [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
+                [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vOut,
+                [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] hint,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineEvalReverseFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern int PipelineEvalReverseFloat_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vIn,
                 [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] vOut,
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] hint,
                 IntPtr handle);
+#endif
 
         internal static int PipelineEvalReverseFloat(IntPtr handle, float[] vIn, float[] vOut, float[] hint)
         {
             return PipelineEvalReverseFloat_Internal(vIn, vOut, hint, handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineEval16")]
+        private static partial void PipelineEval16_Internal(
+                [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] vIn,
+                [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] vOut,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineEval16", CallingConvention = CallingConvention.StdCall)]
         private static extern void PipelineEval16_Internal(
                 [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] vIn,
                 [In, Out, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] vOut,
                 IntPtr handle);
+#endif
 
         internal static void PipelineEval16(IntPtr handle, ushort[] vIn, ushort[] vOut)
         {
             PipelineEval16_Internal(vIn, vOut, handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineInsertStage")]
+        private static partial int PipelineInsertStage_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int location,
+                IntPtr stage);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineInsertStage", CallingConvention = CallingConvention.StdCall)]
         private static extern int PipelineInsertStage_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int location,
                 IntPtr stage);
+#endif
 
         internal static int PipelineInsertStage(IntPtr handle, IntPtr stage, int location)
         {
             return PipelineInsertStage_Internal(handle, location, stage);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineInputChannels")]
+        private static partial uint PipelineInputChannels_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineInputChannels", CallingConvention = CallingConvention.StdCall)]
         private static extern uint PipelineInputChannels_Internal(IntPtr handle);
+#endif
 
         internal static uint PipelineInputChannels(IntPtr handle)
         {
             return PipelineInputChannels_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineOutputChannels")]
+        private static partial uint PipelineOutputChannels_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineOutputChannels", CallingConvention = CallingConvention.StdCall)]
         private static extern uint PipelineOutputChannels_Internal(IntPtr handle);
+#endif
 
         internal static uint PipelineOutputChannels(IntPtr handle)
         {
             return PipelineOutputChannels_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineStageCount")]
+        private static partial uint PipelineStageCount_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineStageCount", CallingConvention = CallingConvention.StdCall)]
         private static extern uint PipelineStageCount_Internal(IntPtr handle);
+#endif
 
         internal static uint PipelineStageCount(IntPtr handle)
         {
             return PipelineStageCount_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineUnlinkStage")]
+        private static partial void PipelineUnlinkStage_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int location,
+                ref IntPtr stage);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineUnlinkStage", CallingConvention = CallingConvention.StdCall)]
         private static extern void PipelineUnlinkStage_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int location,
                 ref IntPtr stage);
+#endif
 
         internal static void PipelineUnlinkStage(IntPtr handle, int location)
         {
@@ -149,32 +231,60 @@ namespace lcmsNET
             PipelineUnlinkStage_Internal(handle, location, ref stage);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToFirstStage")]
+        private static partial IntPtr PipelineGetPtrToFirstStage_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToFirstStage", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr PipelineGetPtrToFirstStage_Internal(IntPtr handle);
+#endif
 
         internal static IntPtr PipelineGetPtrToFirstStage(IntPtr handle)
         {
             return PipelineGetPtrToFirstStage_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToLastStage")]
+        private static partial IntPtr PipelineGetPtrToLastStage_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineGetPtrToLastStage", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr PipelineGetPtrToLastStage_Internal(IntPtr handle);
+#endif
 
         internal static IntPtr PipelineGetPtrToLastStage(IntPtr handle)
         {
             return PipelineGetPtrToLastStage_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsPipelineSetSaveAs8bitsFlag")]
+        private static partial int PipelineSetSaveAs8bitsFlag_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int on);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsPipelineSetSaveAs8bitsFlag", CallingConvention = CallingConvention.StdCall)]
         private static extern int PipelineSetSaveAs8bitsFlag_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int on);
+#endif
 
         internal static int PipelineSetSaveAs8BitsFlag(IntPtr handle, int on)
         {
             return PipelineSetSaveAs8bitsFlag_Internal(handle, on);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsDefaultICCintents")]
+        private static partial IntPtr DefaultICCIntents_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
+                uint[] intents,
+                IntPtr[] profiles,
+                int[] bpc,
+                double[] adaptationStates,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsDefaultICCintents", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DefaultICCIntents_Internal(
                 IntPtr contextID,
@@ -184,6 +294,7 @@ namespace lcmsNET
                 int[] bpc,
                 double[] adaptationStates,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr DefaultICCIntents(IntPtr contextID, uint[] intents, IntPtr[] profiles, int[] bpc,
                 double[] adaptationStates, uint flags)
@@ -191,6 +302,15 @@ namespace lcmsNET
             return DefaultICCIntents_Internal(contextID, (uint)profiles.Length, intents, profiles, bpc, adaptationStates, flags);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsPipelineSetOptimizationParameters")]
+        internal static partial void PipelineSetOptimizationParameters_Internal(
+                IntPtr handle,
+                IntPtr eval16Ptr,
+                IntPtr privateData,
+                IntPtr freePrivateDataPtr,
+                IntPtr dupPrivateDataPtr);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsPipelineSetOptimizationParameters", CallingConvention = CallingConvention.StdCall)]
         internal static extern void PipelineSetOptimizationParameters_Internal(
                 IntPtr handle,
@@ -198,6 +318,7 @@ namespace lcmsNET
                 IntPtr privateData,
                 IntPtr freePrivateDataPtr,
                 IntPtr dupPrivateDataPtr);
+#endif
 
         internal static void PipelineSetOptimizationParameters(IntPtr handle, OptEval16 eval16, IntPtr privateData,
                 FreeUserData freePrivateDataFn, DupUserData dupUserDataFn)

--- a/src/lcmsNET/Interop/Interop.Profile.cs
+++ b/src/lcmsNET/Interop/Interop.Profile.cs
@@ -28,95 +28,163 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateProfilePlaceholder")]
+        private static partial IntPtr CreateProfilePlaceholder_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateProfilePlaceholder", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateProfilePlaceholder_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr CreatePlaceholder(IntPtr contextID)
         {
             return CreateProfilePlaceholder_Internal(contextID);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateRGBProfile")]
+        private static partial IntPtr CreateRGBProfile_Internal(
+                in CIExyY whitePoint,
+                in CIExyYTRIPLE primaries,
+                IntPtr[] transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateRGBProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateRGBProfile_Internal(
                 in CIExyY whitePoint,
                 in CIExyYTRIPLE primaries,
                 IntPtr[] transferFunction);
+#endif
 
         internal static IntPtr CreateRGB(in CIExyY whitePoint, in CIExyYTRIPLE primaries, IntPtr[] transferFunction)
         {
             return CreateRGBProfile_Internal(whitePoint, primaries, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateRGBProfileTHR")]
+        private static partial IntPtr CreateRGBProfileTHR_Internal(
+                IntPtr contextID,
+                in CIExyY whitePoint,
+                in CIExyYTRIPLE primaries,
+                IntPtr[] transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateRGBProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateRGBProfileTHR_Internal(
                 IntPtr contextID,
                 in CIExyY whitePoint,
                 in CIExyYTRIPLE primaries,
                 IntPtr[] transferFunction);
+#endif
 
         internal static IntPtr CreateRGB(IntPtr contextID, in CIExyY whitePoint, in CIExyYTRIPLE primaries, IntPtr[] transferFunction)
         {
             return CreateRGBProfileTHR_Internal(contextID, whitePoint, primaries, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateGrayProfile")]
+        private static partial IntPtr CreateGrayProfile_Internal(
+                in CIExyY whitePoint,
+                IntPtr transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateGrayProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateGrayProfile_Internal(
                 in CIExyY whitePoint,
                 IntPtr transferFunction);
+#endif
 
         internal static IntPtr CreateGray(in CIExyY whitePoint, IntPtr transferFunction)
         {
             return CreateGrayProfile_Internal(whitePoint, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateGrayProfileTHR")]
+        private static partial IntPtr CreateGrayProfileTHR_Internal(
+                IntPtr contextID,
+                in CIExyY whitePoint,
+                IntPtr transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateGrayProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateGrayProfileTHR_Internal(
                 IntPtr contextID,
                 in CIExyY whitePoint,
                 IntPtr transferFunction);
+#endif
 
         internal static IntPtr CreateGray(IntPtr contextID, in CIExyY whitePoint, IntPtr transferFunction)
         {
             return CreateGrayProfileTHR_Internal(contextID, whitePoint, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLink")]
+        private static partial IntPtr CreateLinearizationDeviceLink_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint space,
+                IntPtr[] transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLink", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLinearizationDeviceLink_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint space,
                 IntPtr[] transferFunction);
+#endif
 
         internal static IntPtr CreateLinearizationDeviceLink(uint space, IntPtr[] transferFunction)
         {
             return CreateLinearizationDeviceLink_Internal(space, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLinkTHR")]
+        private static partial IntPtr CreateLinearizationDeviceLinkTHR_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint space,
+                IntPtr[] transferFunction);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLinkTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLinearizationDeviceLinkTHR_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint space,
                 IntPtr[] transferFunction);
+#endif
 
         internal static IntPtr CreateLinearizationDeviceLink(IntPtr contextID, uint space, IntPtr[] transferFunction)
         {
             return CreateLinearizationDeviceLinkTHR_Internal(contextID, space, transferFunction);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLink")]
+        private static partial IntPtr CreateInkLimitingDeviceLink_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint colorSpaceSignature,
+                [MarshalAs(UnmanagedType.R8)] double limit);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLink", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateInkLimitingDeviceLink_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint colorSpaceSignature,
                 [MarshalAs(UnmanagedType.R8)] double limit);
+#endif
 
         internal static IntPtr CreateInkLimitingDeviceLink(uint colorSpaceSignature, double limit)
         {
             return CreateInkLimitingDeviceLink_Internal(colorSpaceSignature, limit);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLinkTHR")]
+        private static partial IntPtr CreateInkLimitingDeviceLinkTHR_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint colorSpaceSignature,
+                [MarshalAs(UnmanagedType.R8)] double limit);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLinkTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateInkLimitingDeviceLinkTHR_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint colorSpaceSignature,
                 [MarshalAs(UnmanagedType.R8)] double limit);
+#endif
 
         internal static IntPtr CreateInkLimitingDeviceLink(IntPtr contextID, uint colorSpaceSignature, double limit)
         {

--- a/src/lcmsNET/Interop/Interop.Profile.cs
+++ b/src/lcmsNET/Interop/Interop.Profile.cs
@@ -651,7 +651,7 @@ namespace lcmsNET
 
         internal static int GetHeaderCreationDateTime(IntPtr handle, out DateTime dest)
         {
-            int size = Marshal.SizeOf(typeof(Tm));
+            int size = Marshal.SizeOf<Tm>();
             IntPtr ptr = Marshal.AllocHGlobal(size);
 
             try

--- a/src/lcmsNET/Interop/Interop.Profile.cs
+++ b/src/lcmsNET/Interop/Interop.Profile.cs
@@ -48,7 +48,7 @@ namespace lcmsNET
         private static partial IntPtr CreateRGBProfile_Internal(
                 in CIExyY whitePoint,
                 in CIExyYTRIPLE primaries,
-                IntPtr[] transferFunction);
+                [In] IntPtr[] transferFunction);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsCreateRGBProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateRGBProfile_Internal(
@@ -68,7 +68,7 @@ namespace lcmsNET
                 IntPtr contextID,
                 in CIExyY whitePoint,
                 in CIExyYTRIPLE primaries,
-                IntPtr[] transferFunction);
+                [In] IntPtr[] transferFunction);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsCreateRGBProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateRGBProfileTHR_Internal(
@@ -123,7 +123,7 @@ namespace lcmsNET
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLink")]
         private static partial IntPtr CreateLinearizationDeviceLink_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint space,
-                IntPtr[] transferFunction);
+                [In] IntPtr[] transferFunction);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLink", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLinearizationDeviceLink_Internal(
@@ -141,7 +141,7 @@ namespace lcmsNET
         private static partial IntPtr CreateLinearizationDeviceLinkTHR_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint space,
-                IntPtr[] transferFunction);
+                [In] IntPtr[] transferFunction);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLinkTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLinearizationDeviceLinkTHR_Internal(
@@ -191,125 +191,230 @@ namespace lcmsNET
             return CreateInkLimitingDeviceLinkTHR_Internal(contextID, colorSpaceSignature, limit);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateDeviceLinkFromCubeFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateDeviceLinkFromCubeFile_Internal(
+                [MarshalAs(UnmanagedType.LPStr)] string filename);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateDeviceLinkFromCubeFile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateDeviceLinkFromCubeFile_Internal(
                 [MarshalAs(UnmanagedType.LPStr)] string filename);
+#endif
 
         internal static IntPtr CreateDeviceLinkFromCubeFile(string filepath)
         {
             return CreateDeviceLinkFromCubeFile_Internal(filepath);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateDeviceLinkFromCubeFileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateDeviceLinkFromCubeFileTHR_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.LPStr)] string filename);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateDeviceLinkFromCubeFileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateDeviceLinkFromCubeFileTHR_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.LPStr)] string filename);
+#endif
 
         internal static IntPtr CreateDeviceLinkFromCubeFile(IntPtr contextID, string filepath)
         {
             return CreateDeviceLinkFromCubeFileTHR_Internal(contextID, filepath);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsTransform2DeviceLink")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr Transform2DeviceLink_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.R8)] double version,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsTransform2DeviceLink", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Transform2DeviceLink_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.R8)] double version,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr Transform2DeviceLink(IntPtr contextID, double version, uint flags)
         {
             return Transform2DeviceLink_Internal(contextID, version, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLab2Profile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateLab2Profile_Internal(
+                in CIExyY whitePoint);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLab2Profile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLab2Profile_Internal(
                 in CIExyY whitePoint);
+#endif
 
         internal static IntPtr CreateLab2(in CIExyY whitePoint)
         {
             return CreateLab2Profile_Internal(whitePoint);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLab2ProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateLab2ProfileTHR_Internal(
+                IntPtr contextID,
+                in CIExyY whitePoint);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLab2ProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLab2ProfileTHR_Internal(
                 IntPtr contextID,
                 in CIExyY whitePoint);
+#endif
 
         internal static IntPtr CreateLab2(IntPtr contextID, in CIExyY whitePoint)
         {
             return CreateLab2ProfileTHR_Internal(contextID, whitePoint);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLab4Profile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateLab4Profile_Internal(
+                in CIExyY whitePoint);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLab4Profile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLab4Profile_Internal(
                 in CIExyY whitePoint);
+#endif
 
         internal static IntPtr CreateLab4(in CIExyY whitePoint)
         {
             return CreateLab4Profile_Internal(whitePoint);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateLab4ProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateLab4ProfileTHR_Internal(
+                IntPtr contextID,
+                in CIExyY whitePoint);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateLab4ProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateLab4ProfileTHR_Internal(
                 IntPtr contextID,
                 in CIExyY whitePoint);
+#endif
 
         internal static IntPtr CreateLab4(IntPtr contextID, in CIExyY whitePoint)
         {
             return CreateLab4ProfileTHR_Internal(contextID, whitePoint);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateXYZProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateXYZProfile_Internal();
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateXYZProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateXYZProfile_Internal();
+#endif
 
         internal static IntPtr CreateXYZ()
         {
             return CreateXYZProfile_Internal();
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateXYZProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateXYZProfileTHR_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateXYZProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateXYZProfileTHR_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr CreateXYZ(IntPtr contextID)
         {
             return CreateXYZProfileTHR_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreate_sRGBProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr Create_sRGBProfile_Internal();
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreate_sRGBProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Create_sRGBProfile_Internal();
+#endif
 
         internal static IntPtr Create_sRGB()
         {
             return Create_sRGBProfile_Internal();
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreate_sRGBProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr Create_sRGBProfileTHR_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreate_sRGBProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Create_sRGBProfileTHR_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr Create_sRGB(IntPtr contextID)
         {
             return Create_sRGBProfileTHR_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateNULLProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateNULLProfile_Internal();
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateNULLProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateNULLProfile_Internal();
+#endif
 
         internal static IntPtr CreateNull()
         {
             return CreateNULLProfile_Internal();
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateNULLProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateNULLProfileTHR_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateNULLProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateNULLProfileTHR_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr CreateNull(IntPtr contextID)
         {
             return CreateNULLProfileTHR_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateBCHSWabstractProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateBCHSWabstractProfile_Internal(
+                [MarshalAs(UnmanagedType.I4)] int nLutPoints,
+                [MarshalAs(UnmanagedType.R8)] double bright,
+                [MarshalAs(UnmanagedType.R8)] double contrast,
+                [MarshalAs(UnmanagedType.R8)] double hue,
+                [MarshalAs(UnmanagedType.R8)] double saturation,
+                [MarshalAs(UnmanagedType.I4)] int tempSrc,
+                [MarshalAs(UnmanagedType.I4)] int tempDest);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateBCHSWabstractProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateBCHSWabstractProfile_Internal(
                 [MarshalAs(UnmanagedType.I4)] int nLutPoints,
@@ -319,6 +424,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.R8)] double saturation,
                 [MarshalAs(UnmanagedType.I4)] int tempSrc,
                 [MarshalAs(UnmanagedType.I4)] int tempDest);
+#endif
 
         internal static IntPtr CreateBCHSWabstract(int nLutPoints, double bright, double contrast,
                 double hue, double saturation, int tempSrc, int tempDest)
@@ -326,6 +432,19 @@ namespace lcmsNET
             return CreateBCHSWabstractProfile_Internal(nLutPoints, bright, contrast, hue, saturation, tempSrc, tempDest);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateBCHSWabstractProfileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateBCHSWabstractProfileTHR_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.I4)] int nLutPoints,
+                [MarshalAs(UnmanagedType.R8)] double bright,
+                [MarshalAs(UnmanagedType.R8)] double contrast,
+                [MarshalAs(UnmanagedType.R8)] double hue,
+                [MarshalAs(UnmanagedType.R8)] double saturation,
+                [MarshalAs(UnmanagedType.I4)] int tempSrc,
+                [MarshalAs(UnmanagedType.I4)] int tempDest);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateBCHSWabstractProfileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateBCHSWabstractProfileTHR_Internal(
                 IntPtr contextID,
@@ -336,6 +455,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.R8)] double saturation,
                 [MarshalAs(UnmanagedType.I4)] int tempSrc,
                 [MarshalAs(UnmanagedType.I4)] int tempDest);
+#endif
 
         internal static IntPtr CreateBCHSWabstract(IntPtr contextID, int nLutPoints, double bright, double contrast,
                 double hue, double saturation, int tempSrc, int tempDest)
@@ -343,19 +463,34 @@ namespace lcmsNET
             return CreateBCHSWabstractProfileTHR_Internal(contextID, nLutPoints, bright, contrast, hue, saturation, tempSrc, tempDest);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreate_OkLabProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr Create_OkLabProfile_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreate_OkLabProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Create_OkLabProfile_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr Create_OkLab(IntPtr contextID)
         {
             return Create_OkLabProfile_Internal(contextID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenProfileFromFile_Internal(
+                [MarshalAs(UnmanagedType.LPStr)] string filename,
+                [MarshalAs(UnmanagedType.LPStr)] string access);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromFile", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenProfileFromFile_Internal(
                 [MarshalAs(UnmanagedType.LPStr)] string filename,
                 [MarshalAs(UnmanagedType.LPStr)] string access);
+#endif
 
         internal static IntPtr OpenProfile(string filepath, string access)
         {
@@ -365,11 +500,20 @@ namespace lcmsNET
             return OpenProfileFromFile_Internal(filepath, access);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromFileTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenProfileFromFileTHR_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.LPStr)] string filename,
+                [MarshalAs(UnmanagedType.LPStr)] string access);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromFileTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenProfileFromFileTHR_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.LPStr)] string filename,
                 [MarshalAs(UnmanagedType.LPStr)] string access);
+#endif
 
         internal static IntPtr OpenProfile(IntPtr contextID, string filepath, string access)
         {
@@ -379,66 +523,114 @@ namespace lcmsNET
             return OpenProfileFromFileTHR_Internal(contextID, filepath, access);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromMem")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr OpenProfileFromMem_Internal(
+                /*const*/ void* memPtr,
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromMem", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern IntPtr OpenProfileFromMem_Internal(
                 /*const*/ void* memPtr,
-                [MarshalAs(UnmanagedType.U4)] int memSize);
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#endif
 
         internal unsafe static IntPtr OpenProfile(byte[] memory)
         {
             fixed (void* memPtr = &memory[0])
             {
-                return OpenProfileFromMem_Internal(memPtr, memory.Length);
+                return OpenProfileFromMem_Internal(memPtr, (uint)memory.Length);
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromMemTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial IntPtr OpenProfileFromMemTHR_Internal(
+                IntPtr contextID,
+                /*const*/ void* memPtr,
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromMemTHR", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern IntPtr OpenProfileFromMemTHR_Internal(
                 IntPtr contextID,
                 /*const*/ void* memPtr,
-                [MarshalAs(UnmanagedType.U4)] int memSize);
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#endif
 
         internal unsafe static IntPtr OpenProfile(IntPtr contextID, byte[] memory)
         {
             fixed (void* memPtr = &memory[0])
             {
-                return OpenProfileFromMemTHR_Internal(contextID, memPtr, memory.Length);
+                return OpenProfileFromMemTHR_Internal(contextID, memPtr, (uint)memory.Length);
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromIOhandlerTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenProfileFromIOhandlerTHR_Internal(
+                IntPtr contextID,
+                IntPtr io);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromIOhandlerTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenProfileFromIOhandlerTHR_Internal(
                 IntPtr contextID,
                 IntPtr io);
+#endif
 
         internal static IntPtr OpenProfile(IntPtr contextID, IntPtr iohandler)
         {
             return OpenProfileFromIOhandlerTHR_Internal(contextID, iohandler);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsOpenProfileFromIOhandler2THR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr OpenProfileFromIOhandler2THR_Internal(
+                IntPtr contextID,
+                IntPtr io,
+                int write);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsOpenProfileFromIOhandler2THR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr OpenProfileFromIOhandler2THR_Internal(
                 IntPtr contextID,
                 IntPtr io,
                 int write);
+#endif
 
         internal static IntPtr OpenProfile(IntPtr contextID, IntPtr iohandler, int writeable)
         {
             return OpenProfileFromIOhandler2THR_Internal(contextID, iohandler, writeable);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCloseProfile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int CloseProfile_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCloseProfile", CallingConvention = CallingConvention.StdCall)]
         private static extern int CloseProfile_Internal(IntPtr handle);
+#endif
 
         internal static int CloseProfile(IntPtr handle)
         {
             return CloseProfile_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSaveProfileToFile")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int SaveProfileToFile_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.LPStr)] string filename);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSaveProfileToFile", CallingConvention = CallingConvention.StdCall)]
         private static extern int SaveProfileToFile_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.LPStr)] string filename);
+#endif
 
         internal static int SaveProfile(IntPtr handle, string filepath)
         {
@@ -447,11 +639,20 @@ namespace lcmsNET
             return SaveProfileToFile_Internal(handle, filepath);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSaveProfileToMem")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial int SaveProfileToMem_Internal(
+                IntPtr handle,
+                void* memPtr,
+                uint* bytesNeeded);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSaveProfileToMem", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern int SaveProfileToMem_Internal(
                 IntPtr handle,
                 void* memPtr,
                 uint* bytesNeeded);
+#endif
 
         internal unsafe static int SaveProfile(IntPtr handle, byte[] memPtr, out uint bytesNeeded)
         {
@@ -472,54 +673,103 @@ namespace lcmsNET
             return result;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSaveProfileToIOhandler")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial uint SaveProfileToIOhandler_Internal(
+                IntPtr handle,
+                IntPtr io);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSaveProfileToIOhandler", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern uint SaveProfileToIOhandler_Internal(
                 IntPtr handle,
                 IntPtr io);
+#endif
 
         internal unsafe static uint SaveProfile(IntPtr handle, IntPtr iohandler)
         {
             return SaveProfileToIOhandler_Internal(handle, iohandler);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetColorSpace")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetColorSpace_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetColorSpace", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetColorSpace_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetColorSpace(IntPtr handle)
         {
             return GetColorSpace_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetColorSpace")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetColorSpace_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint sig);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetColorSpace", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetColorSpace_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint sig);
+#endif
 
         internal static void SetColorSpace(IntPtr handle, uint sig)
         {
             SetColorSpace_Internal(handle, sig);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetPCS")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetPCS_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetPCS", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetPCS_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetPCS(IntPtr handle)
         {
             return GetPCS_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetPCS")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetPCS_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint pcs);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetPCS", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetPCS_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint pcs);
+#endif
 
         internal static void SetPCS(IntPtr handle, uint pcs)
         {
             SetPCS_Internal(handle, pcs);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetProfileInfo")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetProfileInfo_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint info,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                IntPtr buffer, /* wchar_t */
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetProfileInfo", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetProfileInfo_Internal(
                 IntPtr handle,
@@ -528,6 +778,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 IntPtr buffer, /* wchar_t */
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static string GetProfileInfo(IntPtr handle, uint info, string languageCode, string countryCode)
         {
@@ -542,7 +793,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(nbytes);
             try
             {
-                GetProfileInfo_Internal(handle, info, language, country, buffer, bytes);
+                _ = GetProfileInfo_Internal(handle, info, language, country, buffer, bytes);
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
@@ -562,6 +813,17 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetProfileInfoASCII")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetProfileInfoASCII_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U4)] uint info,
+                [In] byte[] languageCode,
+                [In] byte[] countryCode,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetProfileInfoASCII", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetProfileInfoASCII_Internal(
                 IntPtr handle,
@@ -570,6 +832,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeConst = 3)] byte[] countryCode,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static string GetProfileInfoASCII(IntPtr handle, uint info, string languageCode, string countryCode)
         {
@@ -583,7 +846,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(Convert.ToInt32(bytes));
             try
             {
-                GetProfileInfoASCII_Internal(handle, info, language, country, buffer, bytes);
+                _ = GetProfileInfoASCII_Internal(handle, info, language, country, buffer, bytes);
                 return Marshal.PtrToStringAnsi(buffer);
             }
             finally
@@ -592,62 +855,112 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDetectBlackPoint")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int DetectBlackPoint_Internal(
+                out CIEXYZ blackPoint,
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDetectBlackPoint", CallingConvention = CallingConvention.StdCall)]
         private static extern int DetectBlackPoint_Internal(
                 out CIEXYZ blackPoint,
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static int DetectBlackPoint(IntPtr handle, out CIEXYZ blackPoint, uint intent, uint flags)
         {
             return DetectBlackPoint_Internal(out blackPoint, handle, intent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDetectDestinationBlackPoint")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int DetectDestinationBlackPoint_Internal(
+                out CIEXYZ blackPoint,
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDetectDestinationBlackPoint", CallingConvention = CallingConvention.StdCall)]
         private static extern int DetectDestinationBlackPoint_Internal(
                 out CIEXYZ blackPoint,
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static int DetectDestinationBlackPoint(IntPtr handle, out CIEXYZ blackPoint, uint intent, uint flags)
         {
             return DetectDestinationBlackPoint_Internal(out blackPoint, handle, intent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDetectTAC")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double DetectTAC_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDetectTAC", CallingConvention = CallingConvention.StdCall)]
         private static extern double DetectTAC_Internal(
                 IntPtr profile);
+#endif
 
         internal static double DetectTAC(IntPtr handle)
         {
             return DetectTAC_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetDeviceClass")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GetDeviceClass_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetDeviceClass", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetDeviceClass_Internal(
                 IntPtr profile);
+#endif
 
         internal static int GetDeviceClass(IntPtr handle)
         {
             return GetDeviceClass_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetDeviceClass")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetDeviceClass_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint sig);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetDeviceClass", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetDeviceClass_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint sig);
+#endif
 
         internal static void SetDeviceClass(IntPtr handle, uint sig)
         {
             SetDeviceClass_Internal(handle, sig);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderCreationDateTime")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GetHeaderCreationDateTime_Internal(
+                IntPtr profile,
+                IntPtr tm);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderCreationDateTime", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetHeaderCreationDateTime_Internal(
                 IntPtr profile,
                 IntPtr tm);
+#endif
 
         internal static int GetHeaderCreationDateTime(IntPtr handle, out DateTime dest)
         {
@@ -673,67 +986,120 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderFlags")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetHeaderFlags_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderFlags", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetHeaderFlags_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetHeaderFlags(IntPtr handle)
         {
             return GetHeaderFlags_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderFlags")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetHeaderFlags_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderFlags", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetHeaderFlags_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static void SetHeaderFlags(IntPtr handle, uint flags)
         {
             SetHeaderFlags_Internal(handle, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderManufacturer")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetHeaderManufacturer_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderManufacturer", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetHeaderManufacturer_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetHeaderManufacturer(IntPtr handle)
         {
             return GetHeaderManufacturer_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderManufacturer")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetHeaderManufacturer_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderManufacturer", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetHeaderManufacturer_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static void SetHeaderManufacturer(IntPtr handle, uint flags)
         {
             SetHeaderManufacturer_Internal(handle, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderModel")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetHeaderModel_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderModel", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetHeaderModel_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetHeaderModel(IntPtr handle)
         {
             return GetHeaderModel_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderModel")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetHeaderModel_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderModel", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetHeaderModel_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static void SetHeaderModel(IntPtr handle, uint flags)
         {
             SetHeaderModel_Internal(handle, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderAttributes")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void GetHeaderAttributes_Internal(
+                IntPtr profile,
+                out ulong flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderAttributes", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetHeaderAttributes_Internal(
                 IntPtr profile,
                 out ulong flags);
+#endif
 
         internal static ulong GetHeaderAttributes(IntPtr handle)
         {
@@ -741,204 +1107,373 @@ namespace lcmsNET
             return flags;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderAttributes")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetHeaderAttributes_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U8)] ulong flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderAttributes", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetHeaderAttributes_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U8)] ulong flags);
+#endif
 
         internal static void SetHeaderAttributes(IntPtr handle, ulong flags)
         {
             SetHeaderAttributes_Internal(handle, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetProfileVersion")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double GetProfileVersion_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetProfileVersion", CallingConvention = CallingConvention.StdCall)]
         private static extern double GetProfileVersion_Internal(
                 IntPtr profile);
+#endif
 
         internal static double GetProfileVersion(IntPtr handle)
         {
             return GetProfileVersion_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetProfileVersion")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetProfileVersion_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.R8)] double version);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetProfileVersion", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetProfileVersion_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.R8)] double version);
+#endif
 
         internal static void SetProfileVersion(IntPtr handle, double version)
         {
             SetProfileVersion_Internal(handle, version);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetEncodedICCversion")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetEncodedICCVersion_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetEncodedICCversion", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetEncodedICCVersion_Internal(
                 IntPtr profile);
+#endif
 
         internal static uint GetEncodedICCVersion(IntPtr handle)
         {
             return GetEncodedICCVersion_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetEncodedICCversion")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetEncodedICCVersion_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint version);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetEncodedICCversion", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetEncodedICCVersion_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint version);
+#endif
 
         internal static void SetEncodedICCVersion(IntPtr handle, uint version)
         {
             SetEncodedICCVersion_Internal(handle, version);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsMatrixShaper")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IsMatrixShaper_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsMatrixShaper", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsMatrixShaper_Internal(
                 IntPtr profile);
+#endif
 
         internal static int IsMatrixShaper(IntPtr handle)
         {
             return IsMatrixShaper_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsCLUT")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IsCLUT_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint usedDirection);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsCLUT", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsCLUT_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint usedDirection);
+#endif
 
         internal static int IsCLUT(IntPtr handle, uint intent, uint usedDirection)
         {
             return IsCLUT_Internal(handle, intent, usedDirection);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetTagCount")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GetTagCount_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetTagCount", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetTagCount_Internal(
                 IntPtr profile);
+#endif
 
         internal static int GetTagCount(IntPtr handle)
         {
             return GetTagCount_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetTagSignature")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GetTagSignature_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint n);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetTagSignature", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetTagSignature_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint n);
+#endif
 
         internal static int GetTagSignature(IntPtr handle, uint n)
         {
             return GetTagSignature_Internal(handle, n);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsTag")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IsTag_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint tag);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsTag", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsTag_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint tag);
+#endif
 
         internal static int IsTag(IntPtr handle, uint tag)
         {
             return IsTag_Internal(handle, tag);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsReadTag")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr ReadTag_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint tag);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsReadTag", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr ReadTag_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint tag);
+#endif
 
         internal static IntPtr ReadTag(IntPtr handle, uint tag)
         {
             return ReadTag_Internal(handle, tag);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsWriteTag")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int WriteTag_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint tag,
+                IntPtr data);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsWriteTag", CallingConvention = CallingConvention.StdCall)]
         private static extern int WriteTag_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint tag,
                 IntPtr data);
+#endif
 
         internal static int WriteTag(IntPtr handle, uint tag, IntPtr data)
         {
             return WriteTag_Internal(handle, tag, data);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsLinkTag")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int LinkTag_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint tag,
+                [MarshalAs(UnmanagedType.U4)] uint dest);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsLinkTag", CallingConvention = CallingConvention.StdCall)]
         private static extern int LinkTag_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint tag,
                 [MarshalAs(UnmanagedType.U4)] uint dest);
+#endif
 
         internal static int LinkTag(IntPtr handle, uint tag, uint dest)
         {
             return LinkTag_Internal(handle, tag, dest);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsTagLinkedTo")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int TagLinkedTo_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint tag);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsTagLinkedTo", CallingConvention = CallingConvention.StdCall)]
         private static extern int TagLinkedTo_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint tag);
+#endif
 
         internal static int TagLinkedTo(IntPtr handle, uint tag)
         {
             return TagLinkedTo_Internal(handle, tag);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderRenderingIntent")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int GetHeaderRenderingIntent_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderRenderingIntent", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetHeaderRenderingIntent_Internal(
                 IntPtr profile);
+#endif
 
         internal static int GetHeaderRenderingIntent(IntPtr handle)
         {
             return GetHeaderRenderingIntent_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderRenderingIntent")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int SetHeaderRenderingIntent_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderRenderingIntent", CallingConvention = CallingConvention.StdCall)]
         private static extern int SetHeaderRenderingIntent_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint intent);
+#endif
 
         internal static int SetHeaderRenderingIntent(IntPtr handle, uint intent)
         {
             return SetHeaderRenderingIntent_Internal(handle, intent);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsIntentSupported")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int IsIntentSupported_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint usedDirection);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsIntentSupported", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsIntentSupported_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint usedDirection);
+#endif
 
         internal static int IsIntentSupported(IntPtr handle, uint intent, uint usedDirection)
         {
             return IsIntentSupported_Internal(handle, intent, usedDirection);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMD5computeID")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MD5computeID_Internal(
+                IntPtr profile);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMD5computeID", CallingConvention = CallingConvention.StdCall)]
         private static extern int MD5computeID_Internal(
                 IntPtr profile);
+#endif
 
         internal static int MD5ComputeID(IntPtr handle)
         {
             return MD5computeID_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetHeaderProfileID")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void GetHeaderProfileID_Internal(
+                IntPtr profile,
+                [Out] byte[] profileID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetHeaderProfileID", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetHeaderProfileID_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID);
+#endif
 
         internal static void GetHeaderProfileID(IntPtr handle, byte[] profileID)
         {
             GetHeaderProfileID_Internal(handle, profileID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetHeaderProfileID")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetHeaderProfileID_Internal(
+                IntPtr profile,
+                [In] byte[] profileID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetHeaderProfileID", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetHeaderProfileID_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID);
+#endif
 
         internal static void SetHeaderProfileID(IntPtr handle, byte[] profileID)
         {
             SetHeaderProfileID_Internal(handle, profileID);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetPostScriptColorResource")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetPostScriptColorResource_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint type,
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags,
+                IntPtr io);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetPostScriptColorResource", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetPostScriptColorResource_Internal(
                 IntPtr contextID,
@@ -947,12 +1482,24 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)]uint intent,
                 [MarshalAs(UnmanagedType.U4)]uint flags,
                 IntPtr io);
+#endif
 
         internal static uint GetPostScriptColorResource(IntPtr handle, IntPtr contextID, uint type, uint intent, uint flags, IntPtr iohandler)
         {
             return GetPostScriptColorResource_Internal(contextID, type, handle, intent, flags, iohandler);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetPostScriptCSA")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetPostScriptCSA_Internal(
+                IntPtr contextID,
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetPostScriptCSA", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetPostScriptCSA_Internal(
                 IntPtr contextID,
@@ -961,6 +1508,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)]uint flags,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static byte[] GetPostScriptCSA(IntPtr handle, IntPtr contextID, uint intent, uint flags)
         {
@@ -972,7 +1520,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(nbytes);
             try
             {
-                GetPostScriptCSA_Internal(contextID, handle, intent, flags, buffer, bytes);
+                _ = GetPostScriptCSA_Internal(contextID, handle, intent, flags, buffer, bytes);
                 byte[] arr = new byte[nbytes];
                 Marshal.Copy(buffer, arr, 0, nbytes);
                 return arr;
@@ -983,6 +1531,17 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetPostScriptCRD")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetPostScriptCRD_Internal(
+                IntPtr contextID,
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags,
+                IntPtr buffer,
+                [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetPostScriptCRD", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetPostScriptCRD_Internal(
                 IntPtr contextID,
@@ -991,6 +1550,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)]uint flags,
                 IntPtr buffer,
                 [MarshalAs(UnmanagedType.U4)] uint bufferSize);
+#endif
 
         internal static byte[] GetPostScriptCRD(IntPtr handle, IntPtr contextID, uint intent, uint flags)
         {
@@ -1002,7 +1562,7 @@ namespace lcmsNET
             buffer = Marshal.AllocHGlobal(nbytes);
             try
             {
-                GetPostScriptCRD_Internal(contextID, handle, intent, flags, buffer, bytes);
+                _ = GetPostScriptCRD_Internal(contextID, handle, intent, flags, buffer, bytes);
                 byte[] arr = new byte[nbytes];
                 Marshal.Copy(buffer, arr, 0, nbytes);
                 return arr;
@@ -1013,10 +1573,18 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDetectRGBProfileGamma")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double DetectRGBProfileGamma_Internal(
+                IntPtr profile,
+                [MarshalAs(UnmanagedType.R8)] double threshold);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDetectRGBProfileGamma", CallingConvention = CallingConvention.StdCall)]
         private static extern double DetectRGBProfileGamma_Internal(
                 IntPtr profile,
                 [MarshalAs(UnmanagedType.R8)] double threshold);
+#endif
 
         internal static double DetectRGBProfileGamma(IntPtr handle, double threshold)
         {

--- a/src/lcmsNET/Interop/Interop.Profile.cs
+++ b/src/lcmsNET/Interop/Interop.Profile.cs
@@ -28,7 +28,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateProfilePlaceholder")]
         private static partial IntPtr CreateProfilePlaceholder_Internal(
                 IntPtr contextID);
@@ -43,7 +43,7 @@ namespace lcmsNET
             return CreateProfilePlaceholder_Internal(contextID);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateRGBProfile")]
         private static partial IntPtr CreateRGBProfile_Internal(
                 in CIExyY whitePoint,
@@ -62,7 +62,7 @@ namespace lcmsNET
             return CreateRGBProfile_Internal(whitePoint, primaries, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateRGBProfileTHR")]
         private static partial IntPtr CreateRGBProfileTHR_Internal(
                 IntPtr contextID,
@@ -83,7 +83,7 @@ namespace lcmsNET
             return CreateRGBProfileTHR_Internal(contextID, whitePoint, primaries, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateGrayProfile")]
         private static partial IntPtr CreateGrayProfile_Internal(
                 in CIExyY whitePoint,
@@ -100,7 +100,7 @@ namespace lcmsNET
             return CreateGrayProfile_Internal(whitePoint, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateGrayProfileTHR")]
         private static partial IntPtr CreateGrayProfileTHR_Internal(
                 IntPtr contextID,
@@ -119,7 +119,7 @@ namespace lcmsNET
             return CreateGrayProfileTHR_Internal(contextID, whitePoint, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLink")]
         private static partial IntPtr CreateLinearizationDeviceLink_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint space,
@@ -136,7 +136,7 @@ namespace lcmsNET
             return CreateLinearizationDeviceLink_Internal(space, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateLinearizationDeviceLinkTHR")]
         private static partial IntPtr CreateLinearizationDeviceLinkTHR_Internal(
                 IntPtr contextID,
@@ -155,7 +155,7 @@ namespace lcmsNET
             return CreateLinearizationDeviceLinkTHR_Internal(contextID, space, transferFunction);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLink")]
         private static partial IntPtr CreateInkLimitingDeviceLink_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint colorSpaceSignature,
@@ -172,7 +172,7 @@ namespace lcmsNET
             return CreateInkLimitingDeviceLink_Internal(colorSpaceSignature, limit);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsCreateInkLimitingDeviceLinkTHR")]
         private static partial IntPtr CreateInkLimitingDeviceLinkTHR_Internal(
                 IntPtr contextID,

--- a/src/lcmsNET/Interop/Interop.ProfileSequenceDescriptor.cs
+++ b/src/lcmsNET/Interop/Interop.ProfileSequenceDescriptor.cs
@@ -25,27 +25,48 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsAllocProfileSequenceDescription")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr AllocProfileSequenceDescription_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nItems);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsAllocProfileSequenceDescription", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr AllocProfileSequenceDescription_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint nItems);
+#endif
 
         internal static IntPtr AllocProfileSequenceDescription(IntPtr contextID, uint nItems)
         {
             return AllocProfileSequenceDescription_Internal(contextID, nItems);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsFreeProfileSequenceDescription")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void FreeProfileSequenceDescription_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFreeProfileSequenceDescription", CallingConvention = CallingConvention.StdCall)]
         private static extern void FreeProfileSequenceDescription_Internal(IntPtr handle);
+#endif
 
         internal static void FreeProfileSequenceDescription(IntPtr handle)
         {
             FreeProfileSequenceDescription_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDupProfileSequenceDescription")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr DupProfileSequenceDescription_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDupProfileSequenceDescription", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DupProfileSequenceDescription_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DupProfileSequenceDescription(IntPtr handle)
         {

--- a/src/lcmsNET/Interop/Interop.Stage.cs
+++ b/src/lcmsNET/Interop/Interop.Stage.cs
@@ -25,27 +25,65 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocIdentity")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocIdentity_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nChannels);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocIdentity", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocIdentity_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint nChannels);
+#endif
 
         internal static IntPtr StageAllocIdentity(IntPtr contextID, uint nChannels)
         {
             return StageAllocIdentity_Internal(contextID, nChannels);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocToneCurves")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocToneCurves_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nChannels,
+                [In] IntPtr[] curves);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocToneCurves", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocToneCurves_Internal(
                 IntPtr contextID,
                 [MarshalAs(UnmanagedType.U4)] uint nChannels,
                 IntPtr[] curves);
+#endif
 
         internal static IntPtr StageAllocToneCurves(IntPtr contextID, uint nChannels, IntPtr[] curves)
         {
             return StageAllocToneCurves_Internal(contextID, nChannels, curves);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocMatrix")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocMatrix_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint rows,
+                [MarshalAs(UnmanagedType.U4)] uint columns,
+                [In] double[] matrix,
+                [In] double[] offset);
+
+        internal static IntPtr StageAllocMatrix(IntPtr contextID, double[,] matrix, double[] offset)
+        {
+            // flatten the 2D array to a 1D array in row-major order
+            uint rows = Convert.ToUInt32(matrix.GetUpperBound(0) + 1);
+            uint columns = Convert.ToUInt32(matrix.GetUpperBound(1) + 1);
+            double[] flatMatrix = new double[rows * columns];
+            Buffer.BlockCopy(matrix, 0, flatMatrix, 0, flatMatrix.Length * sizeof(double));
+
+            return StageAllocMatrix_Internal(contextID, rows, columns, flatMatrix, offset);
+        }
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocMatrix", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocMatrix_Internal(
                 IntPtr contextID,
@@ -59,7 +97,18 @@ namespace lcmsNET
             return StageAllocMatrix_Internal(contextID, Convert.ToUInt32(matrix.GetUpperBound(0)+1),
                     Convert.ToUInt32(matrix.GetUpperBound(1)+1), matrix, offset);
         }
+#endif
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocCLut16bit")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocCLut16bit_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nGridPoints,
+                [MarshalAs(UnmanagedType.U4)] uint inputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint outputChannels,
+                [In] ushort[] curves);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocCLut16bit", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocCLut16bit_Internal(
                 IntPtr contextID,
@@ -67,12 +116,23 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint inputChannels,
                 [MarshalAs(UnmanagedType.U4)] uint outputChannels,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] curves);
+#endif
 
         internal static IntPtr StageAllocCLut16bit(IntPtr contextID, uint nGridPoints, uint inputChannels, uint outputChannels, ushort[] table)
         {
             return StageAllocCLut16bit_Internal(contextID, nGridPoints, inputChannels, outputChannels, table);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocCLutFloat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocCLutFloat_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nGridPoints,
+                [MarshalAs(UnmanagedType.U4)] uint inputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint outputChannels,
+                [In] float[] curves);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocCLutFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocCLutFloat_Internal(
                 IntPtr contextID,
@@ -80,12 +140,23 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint inputChannels,
                 [MarshalAs(UnmanagedType.U4)] uint outputChannels,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] curves);
+#endif
 
         internal static IntPtr StageAllocCLutFloat(IntPtr contextID, uint nGridPoints, uint inputChannels, uint outputChannels, float[] table)
         {
             return StageAllocCLutFloat_Internal(contextID, nGridPoints, inputChannels, outputChannels, table);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocCLut16bitGranular")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocCLut16bitGranular_Internal(
+                IntPtr contextID,
+                [In] uint[] clutPoints,
+                [MarshalAs(UnmanagedType.U4)] uint inputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint outputChannels,
+                [In] ushort[] table);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocCLut16bitGranular", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocCLut16bitGranular_Internal(
                 IntPtr contextID,
@@ -93,12 +164,23 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint inputChannels,
                 [MarshalAs(UnmanagedType.U4)] uint outputChannels,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] table);
+#endif
 
         internal static IntPtr StageAllocCLut16bitGranular(IntPtr contextID, uint[] clutPoints, uint outputChannels, ushort[] table)
         {
             return StageAllocCLut16bitGranular_Internal(contextID, clutPoints, Convert.ToUInt32(clutPoints.Length), outputChannels, table);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageAllocCLutFloatGranular")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocCLutFloatGranular_Internal(
+                IntPtr contextID,
+                [In] uint[] clutPoints,
+                [MarshalAs(UnmanagedType.U4)] uint inputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint outputChannels,
+                [In] float[] table);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageAllocCLutFloatGranular", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocCLutFloatGranular_Internal(
                 IntPtr contextID,
@@ -106,120 +188,211 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint inputChannels,
                 [MarshalAs(UnmanagedType.U4)] uint outputChannels,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] table);
+#endif
 
         internal static IntPtr StageAllocCLutFloatGranular(IntPtr contextID, uint[] clutPoints, uint outputChannels, float[] table)
         {
             return StageAllocCLutFloatGranular_Internal(contextID, clutPoints, Convert.ToUInt32(clutPoints.Length), outputChannels, table);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageDup")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageDup_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageDup", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageDup_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr StageDup(IntPtr handle)
         {
             return StageDup_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageFree")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void StageFree_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageFree", CallingConvention = CallingConvention.StdCall)]
         private static extern void StageFree_Internal(IntPtr handle);
+#endif
 
         internal static void StageFree(IntPtr handle)
         {
             StageFree_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageInputChannels")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint StageInputChannels_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageInputChannels", CallingConvention = CallingConvention.StdCall)]
         private static extern uint StageInputChannels_Internal(IntPtr handle);
+#endif
 
         internal static uint StageInputChannels(IntPtr handle)
         {
             return StageInputChannels_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageOutputChannels")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint StageOutputChannels_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageOutputChannels", CallingConvention = CallingConvention.StdCall)]
         private static extern uint StageOutputChannels_Internal(IntPtr handle);
+#endif
 
         internal static uint StageOutputChannels(IntPtr handle)
         {
             return StageOutputChannels_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageType")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint StageType_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageType", CallingConvention = CallingConvention.StdCall)]
         private static extern uint StageType_Internal(IntPtr handle);
+#endif
 
         internal static uint StageType(IntPtr handle)
         {
             return StageType_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageData")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageData_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageData", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageData_Internal(IntPtr handle);
+#endif
 
         internal static IntPtr StageData(IntPtr handle)
         {
             return StageData_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageNext")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageNext_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageNext", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageNext_Internal(IntPtr handle);
+#endif
 
         internal static IntPtr StageNext(IntPtr handle)
         {
             return StageNext_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageSampleCLut16bit")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int StageSampleCLut16bit_Internal(
+                IntPtr mpe,
+                Sampler16 sampler,
+                IntPtr cargo,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageSampleCLut16bit", CallingConvention = CallingConvention.StdCall)]
         private static extern int StageSampleCLut16bit_Internal(
                 IntPtr mpe,
                 Sampler16 sampler,
                 IntPtr cargo,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static int StageSampleClut16Bit(IntPtr handle, Sampler16 sampler, IntPtr cargo, uint flags)
         {
             return StageSampleCLut16bit_Internal(handle, sampler, cargo, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsStageSampleCLutFloat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int StageSampleCLutFloat_Internal(
+                IntPtr mpe,
+                SamplerFloat sampler,
+                IntPtr cargo,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsStageSampleCLutFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern int StageSampleCLutFloat_Internal(
                 IntPtr mpe,
                 SamplerFloat sampler,
                 IntPtr cargo,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static int StageSampleClutFloat(IntPtr handle, SamplerFloat sampler, IntPtr cargo, uint flags)
         {
             return StageSampleCLutFloat_Internal(handle, sampler, cargo, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSliceSpace16")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int SliceSpace16_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint nPoints,
+                [In] uint[] clutPoints,
+                Sampler16 sampler,
+                IntPtr cargo);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSliceSpace16", CallingConvention = CallingConvention.StdCall)]
         private static extern int SliceSpace16_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint nPoints,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] clutPoints,
                 Sampler16 sampler,
                 IntPtr cargo);
+#endif
 
         internal static int SliceSpace16Bit(uint nPoints, uint[] clutPoints, Sampler16 sampler, IntPtr cargo)
         {
             return SliceSpace16_Internal(nPoints, clutPoints, sampler, cargo);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsSliceSpaceFloat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int SliceSpaceFloat_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint nPoints,
+                [In] uint[] clutPoints,
+                SamplerFloat sampler,
+                IntPtr cargo);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSliceSpaceFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern int SliceSpaceFloat_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint nPoints,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] clutPoints,
                 SamplerFloat sampler,
                 IntPtr cargo);
+#endif
 
         internal static int SliceSpaceFloat(uint nPoints, uint[] clutPoints, SamplerFloat sampler, IntPtr cargo)
         {
             return SliceSpaceFloat_Internal(nPoints, clutPoints, sampler, cargo);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetStageContextID")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GetStageContextID_Internal(
+                IntPtr mpe);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetStageContextID", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetStageContextID_Internal(
                 IntPtr mpe);
+#endif
 
         internal static IntPtr GetStageContextID(IntPtr handle)
         {
@@ -234,6 +407,19 @@ namespace lcmsNET
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsStageAllocPlaceholder")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr StageAllocPlaceholder_Internal(
+                IntPtr ContextID,
+                [MarshalAs(UnmanagedType.U4)] uint Type,
+                [MarshalAs(UnmanagedType.U4)] uint InputChannels,
+                [MarshalAs(UnmanagedType.U4)] uint OutputChannels,
+                IntPtr EvalPtr,
+                IntPtr DupElemPtr,
+                IntPtr FreePtr,
+                IntPtr Data);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsStageAllocPlaceholder", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr StageAllocPlaceholder_Internal(
                 IntPtr ContextID,
@@ -244,6 +430,7 @@ namespace lcmsNET
                 IntPtr DupElemPtr,
                 IntPtr FreePtr,
                 IntPtr Data);
+#endif
 
         internal static IntPtr StageAllocPlaceholder(IntPtr contextId, uint type, uint inputChannels, uint outputChannels,
                 StageEvalFn evalFn, StageDupElemFn dupElemFn, StageFreeElemFn freeElemFn, IntPtr data)

--- a/src/lcmsNET/Interop/Interop.ToneCurve.cs
+++ b/src/lcmsNET/Interop/Interop.ToneCurve.cs
@@ -65,7 +65,7 @@ namespace lcmsNET
         private static partial IntPtr BuildParametricToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int type,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8)] double[] parameters);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8)] [In] double[] parameters);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsBuildParametricToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildParametricToneCurve_Internal(
@@ -143,7 +143,7 @@ namespace lcmsNET
         private static partial IntPtr BuildTabulatedToneCurve16_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] parameters);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] [In] ushort[] parameters);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurve16", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildTabulatedToneCurve16_Internal(
@@ -162,7 +162,7 @@ namespace lcmsNET
         private static partial IntPtr BuildTabulatedToneCurveFloat_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] parameters);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] [In] float[] parameters);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurveFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildTabulatedToneCurveFloat_Internal(

--- a/src/lcmsNET/Interop/Interop.ToneCurve.cs
+++ b/src/lcmsNET/Interop/Interop.ToneCurve.cs
@@ -26,52 +26,89 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurveFloat")]
+        private static partial float EvalToneCurveFloat_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R4)] float v);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsEvalToneCurveFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern float EvalToneCurveFloat_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R4)] float v);
+#endif
 
         internal static float EvaluateToneCurve(IntPtr contextID, float v)
         {
             return EvalToneCurveFloat_Internal(contextID, v);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurve16")]
+        private static partial ushort EvalToneCurve16_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.U2)] ushort v);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsEvalToneCurve16", CallingConvention = CallingConvention.StdCall)]
         private static extern ushort EvalToneCurve16_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U2)] ushort v);
+#endif
 
         internal static ushort EvaluateToneCurve(IntPtr contextID, ushort v)
         {
             return EvalToneCurve16_Internal(contextID, v);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsBuildParametricToneCurve")]
+        private static partial IntPtr BuildParametricToneCurve_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int type,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8)] double[] parameters);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBuildParametricToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildParametricToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int type,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R8)] double[] parameters);
+#endif
 
         internal static IntPtr BuildParametricToneCurve(IntPtr contextID, int type, double[] parameters)
         {
             return BuildParametricToneCurve_Internal(contextID, type, parameters);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsBuildGamma")]
+        private static partial IntPtr BuildGamma_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R8)] double gamma);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBuildGamma", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildGamma_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double gamma);
+#endif
 
         internal static IntPtr BuildGammaToneCurve(IntPtr contextID, double gamma)
         {
             return BuildGamma_Internal(contextID, gamma);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsBuildSegmentedToneCurve")]
+        private static partial IntPtr BuildSegmentedToneCurve_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int nSegments,
+                IntPtr segments);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBuildSegmentedToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildSegmentedToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nSegments,
                 IntPtr segments);
+#endif
 
         internal static IntPtr BuildSegmentedToneCurve(IntPtr contextID, CurveSegment[] segments)
         {
@@ -101,145 +138,245 @@ namespace lcmsNET
             }
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurve16")]
+        private static partial IntPtr BuildTabulatedToneCurve16_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int nEntries,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] parameters);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurve16", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildTabulatedToneCurve16_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2)] ushort[] parameters);
+#endif
 
         internal static IntPtr BuildTabulatedToneCurve(IntPtr contextID, ushort[] values)
         {
             return BuildTabulatedToneCurve16_Internal(contextID, values.Length, values);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurveFloat")]
+        private static partial IntPtr BuildTabulatedToneCurveFloat_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.I4)] int nEntries,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] parameters);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurveFloat", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr BuildTabulatedToneCurveFloat_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.R4)] float[] parameters);
+#endif
 
         internal static IntPtr BuildTabulatedToneCurve(IntPtr contextID, float[] values)
         {
             return BuildTabulatedToneCurveFloat_Internal(contextID, values.Length, values);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsDupToneCurve")]
+        private static partial IntPtr DupToneCurve_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDupToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DupToneCurve_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr DuplicateToneCurve(IntPtr handle)
         {
             return DupToneCurve_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurve")]
+        private static partial IntPtr ReverseToneCurve_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsReverseToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr ReverseToneCurve_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr ReverseToneCurve(IntPtr handle)
         {
             return ReverseToneCurve_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurveEx")]
+        private static partial IntPtr ReverseToneCurveEx_Internal(
+                [MarshalAs(UnmanagedType.I4)] int nResultSamples,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsReverseToneCurveEx", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr ReverseToneCurveEx_Internal(
                 [MarshalAs(UnmanagedType.I4)] int nResultSamples,
                 IntPtr handle);
+#endif
 
         internal static IntPtr ReverseToneCurve(IntPtr handle, int nResultSamples)
         {
             return ReverseToneCurveEx_Internal(nResultSamples, handle);
         }
 
+#if NET8_0
+        // Use classic DllImport for this signature because source-generated P/Invoke
+        // does not support MarshalAs(UnmanagedType.U4) on int parameters (SYSLIB1052).
         [DllImport(Liblcms, EntryPoint = "cmsJoinToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr JoinToneCurve_Internal(
                 IntPtr contextID,
                 IntPtr x,
                 IntPtr y,
                 [MarshalAs(UnmanagedType.U4)] int nPoints);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsJoinToneCurve", CallingConvention = CallingConvention.StdCall)]
+        private static extern IntPtr JoinToneCurve_Internal(
+                IntPtr contextID,
+                IntPtr x,
+                IntPtr y,
+                [MarshalAs(UnmanagedType.U4)] int nPoints);
+#endif
 
         internal static IntPtr JoinToneCurve(IntPtr contextID, IntPtr x, IntPtr y, int nPoints)
         {
             return JoinToneCurve_Internal(contextID, x, y, nPoints);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSmoothToneCurve")]
+        private static partial int SmoothToneCurve_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R8)] double lambda);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSmoothToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern int SmoothToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double lambda);
+#endif
 
         internal static int SmoothToneCurve(IntPtr handle, double lambda)
         {
             return SmoothToneCurve_Internal(handle, lambda);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMultisegment")]
+        private static partial int IsToneCurveMultisegment_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsToneCurveMultisegment", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsToneCurveMultisegment_Internal(
                 IntPtr handle);
+#endif
 
         internal static int IsMultiSegmentToneCurve(IntPtr handle)
         {
             return IsToneCurveMultisegment_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveLinear")]
+        private static partial int IsToneCurveLinear_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsToneCurveLinear", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsToneCurveLinear_Internal(
                 IntPtr handle);
+#endif
 
         internal static int IsLinearToneCurve(IntPtr handle)
         {
             return IsToneCurveLinear_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMonotonic")]
+        private static partial int IsToneCurveMonotonic_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsToneCurveMonotonic", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsToneCurveMonotonic_Internal(
                 IntPtr handle);
+#endif
 
         internal static int IsMonotonicToneCurve(IntPtr handle)
         {
             return IsToneCurveMonotonic_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveDescending")]
+        private static partial int IsToneCurveDescending_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsIsToneCurveDescending", CallingConvention = CallingConvention.StdCall)]
         private static extern int IsToneCurveDescending_Internal(
                 IntPtr handle);
+#endif
 
         internal static int IsDescendingToneCurve(IntPtr handle)
         {
             return IsToneCurveDescending_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsEstimateGamma")]
+        private static partial double EstimateGamma_Internal(
+                IntPtr handle,
+                [MarshalAs(UnmanagedType.R8)] double precision);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsEstimateGamma", CallingConvention = CallingConvention.StdCall)]
         private static extern double EstimateGamma_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double precision);
+#endif
 
         internal static double EstimateGamma(IntPtr handle, double precision)
         {
             return EstimateGamma_Internal(handle, precision);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTableEntries")]
+        private static partial uint GetToneCurveEstimatedTableEntries_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTableEntries", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetToneCurveEstimatedTableEntries_Internal(
                 IntPtr handle);
+#endif
 
         internal static uint GetEstimatedTableEntries(IntPtr handle)
         {
             return GetToneCurveEstimatedTableEntries_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTable")]
+        private static partial IntPtr GetToneCurveEstimatedTable_Internal(
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTable", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetToneCurveEstimatedTable_Internal(
                 IntPtr handle);
+#endif
 
         internal static IntPtr GetEstimatedTable(IntPtr handle)
         {
             return GetToneCurveEstimatedTable_Internal(handle);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsFreeToneCurve")]
+        private static partial void FreeToneCurve_Internal(IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsFreeToneCurve", CallingConvention = CallingConvention.StdCall)]
-        private static extern void FreeToneCurve_Internal(
-                IntPtr handle);
+        private static extern void FreeToneCurve_Internal(IntPtr handle);
+#endif
 
         internal static void FreeToneCurve(IntPtr handle)
         {

--- a/src/lcmsNET/Interop/Interop.ToneCurve.cs
+++ b/src/lcmsNET/Interop/Interop.ToneCurve.cs
@@ -125,7 +125,7 @@ namespace lcmsNET
                     Marshal.StructureToPtr(segment, segmentPtr, false);
                     Marshal.Copy(segmentPtr, temp, start, segmentLength);
                     start += segmentLength;
-                    Marshal.DestroyStructure(segmentPtr, typeof(CurveSegment));
+                    Marshal.DestroyStructure<CurveSegment>(segmentPtr);
                     Marshal.FreeHGlobal(segmentPtr);
                 }
                 Marshal.Copy(temp, 0, ptr, totalSize);

--- a/src/lcmsNET/Interop/Interop.ToneCurve.cs
+++ b/src/lcmsNET/Interop/Interop.ToneCurve.cs
@@ -26,7 +26,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurveFloat")]
         private static partial float EvalToneCurveFloat_Internal(
                 IntPtr handle,
@@ -43,7 +43,7 @@ namespace lcmsNET
             return EvalToneCurveFloat_Internal(contextID, v);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurve16")]
         private static partial ushort EvalToneCurve16_Internal(
                 IntPtr handle,
@@ -60,7 +60,7 @@ namespace lcmsNET
             return EvalToneCurve16_Internal(contextID, v);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildParametricToneCurve")]
         private static partial IntPtr BuildParametricToneCurve_Internal(
                 IntPtr handle,
@@ -79,7 +79,7 @@ namespace lcmsNET
             return BuildParametricToneCurve_Internal(contextID, type, parameters);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildGamma")]
         private static partial IntPtr BuildGamma_Internal(
                 IntPtr handle,
@@ -96,7 +96,7 @@ namespace lcmsNET
             return BuildGamma_Internal(contextID, gamma);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildSegmentedToneCurve")]
         private static partial IntPtr BuildSegmentedToneCurve_Internal(
                 IntPtr handle,
@@ -138,7 +138,7 @@ namespace lcmsNET
             }
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurve16")]
         private static partial IntPtr BuildTabulatedToneCurve16_Internal(
                 IntPtr handle,
@@ -157,7 +157,7 @@ namespace lcmsNET
             return BuildTabulatedToneCurve16_Internal(contextID, values.Length, values);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurveFloat")]
         private static partial IntPtr BuildTabulatedToneCurveFloat_Internal(
                 IntPtr handle,
@@ -176,7 +176,7 @@ namespace lcmsNET
             return BuildTabulatedToneCurveFloat_Internal(contextID, values.Length, values);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsDupToneCurve")]
         private static partial IntPtr DupToneCurve_Internal(
                 IntPtr handle);
@@ -191,7 +191,7 @@ namespace lcmsNET
             return DupToneCurve_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurve")]
         private static partial IntPtr ReverseToneCurve_Internal(
                 IntPtr handle);
@@ -206,7 +206,7 @@ namespace lcmsNET
             return ReverseToneCurve_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurveEx")]
         private static partial IntPtr ReverseToneCurveEx_Internal(
                 [MarshalAs(UnmanagedType.I4)] int nResultSamples,
@@ -223,30 +223,30 @@ namespace lcmsNET
             return ReverseToneCurveEx_Internal(nResultSamples, handle);
         }
 
-#if NET8_0
-        // Use classic DllImport for this signature because source-generated P/Invoke
-        // does not support MarshalAs(UnmanagedType.U4) on int parameters (SYSLIB1052).
-        [DllImport(Liblcms, EntryPoint = "cmsJoinToneCurve", CallingConvention = CallingConvention.StdCall)]
-        private static extern IntPtr JoinToneCurve_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsJoinToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr JoinToneCurve_Internal(
                 IntPtr contextID,
                 IntPtr x,
                 IntPtr y,
-                [MarshalAs(UnmanagedType.U4)] int nPoints);
+                [MarshalAs(UnmanagedType.U4)] uint nPoints);
 #else
+        // Use classic DllImport but change parameter to uint to match UnmanagedType.U4.
         [DllImport(Liblcms, EntryPoint = "cmsJoinToneCurve", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr JoinToneCurve_Internal(
                 IntPtr contextID,
                 IntPtr x,
                 IntPtr y,
-                [MarshalAs(UnmanagedType.U4)] int nPoints);
+                [MarshalAs(UnmanagedType.U4)] uint nPoints);
 #endif
 
         internal static IntPtr JoinToneCurve(IntPtr contextID, IntPtr x, IntPtr y, int nPoints)
         {
-            return JoinToneCurve_Internal(contextID, x, y, nPoints);
+            return JoinToneCurve_Internal(contextID, x, y, (uint)nPoints);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSmoothToneCurve")]
         private static partial int SmoothToneCurve_Internal(
                 IntPtr handle,
@@ -263,7 +263,7 @@ namespace lcmsNET
             return SmoothToneCurve_Internal(handle, lambda);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMultisegment")]
         private static partial int IsToneCurveMultisegment_Internal(
                 IntPtr handle);
@@ -278,7 +278,7 @@ namespace lcmsNET
             return IsToneCurveMultisegment_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveLinear")]
         private static partial int IsToneCurveLinear_Internal(
                 IntPtr handle);
@@ -293,7 +293,7 @@ namespace lcmsNET
             return IsToneCurveLinear_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMonotonic")]
         private static partial int IsToneCurveMonotonic_Internal(
                 IntPtr handle);
@@ -308,7 +308,7 @@ namespace lcmsNET
             return IsToneCurveMonotonic_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveDescending")]
         private static partial int IsToneCurveDescending_Internal(
                 IntPtr handle);
@@ -323,7 +323,7 @@ namespace lcmsNET
             return IsToneCurveDescending_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEstimateGamma")]
         private static partial double EstimateGamma_Internal(
                 IntPtr handle,
@@ -340,7 +340,7 @@ namespace lcmsNET
             return EstimateGamma_Internal(handle, precision);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTableEntries")]
         private static partial uint GetToneCurveEstimatedTableEntries_Internal(
                 IntPtr handle);
@@ -355,7 +355,7 @@ namespace lcmsNET
             return GetToneCurveEstimatedTableEntries_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTable")]
         private static partial IntPtr GetToneCurveEstimatedTable_Internal(
                 IntPtr handle);
@@ -370,7 +370,7 @@ namespace lcmsNET
             return GetToneCurveEstimatedTable_Internal(handle);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsFreeToneCurve")]
         private static partial void FreeToneCurve_Internal(IntPtr handle);
 #else
@@ -383,10 +383,19 @@ namespace lcmsNET
             FreeToneCurve_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveSegment")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GetToneCurveSegment_Internal(
+                [MarshalAs(UnmanagedType.I4)] int segment,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetToneCurveSegment", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetToneCurveSegment_Internal(
                 [MarshalAs(UnmanagedType.I4)] int segment,
                 IntPtr handle);
+#endif
+
         internal static IntPtr GetCurveSegment(IntPtr handle, int segment)
         {
             return GetToneCurveSegment_Internal(segment, handle);

--- a/src/lcmsNET/Interop/Interop.ToneCurve.cs
+++ b/src/lcmsNET/Interop/Interop.ToneCurve.cs
@@ -28,6 +28,7 @@ namespace lcmsNET
     {
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurveFloat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial float EvalToneCurveFloat_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R4)] float v);
@@ -45,6 +46,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEvalToneCurve16")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial ushort EvalToneCurve16_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.U2)] ushort v);
@@ -62,6 +64,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildParametricToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr BuildParametricToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int type,
@@ -81,6 +84,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildGamma")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr BuildGamma_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double gamma);
@@ -98,6 +102,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildSegmentedToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr BuildSegmentedToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nSegments,
@@ -140,6 +145,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurve16")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr BuildTabulatedToneCurve16_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
@@ -159,6 +165,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsBuildTabulatedToneCurveFloat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr BuildTabulatedToneCurveFloat_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.I4)] int nEntries,
@@ -178,6 +185,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsDupToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr DupToneCurve_Internal(
                 IntPtr handle);
 #else
@@ -193,6 +201,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr ReverseToneCurve_Internal(
                 IntPtr handle);
 #else
@@ -208,6 +217,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsReverseToneCurveEx")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr ReverseToneCurveEx_Internal(
                 [MarshalAs(UnmanagedType.I4)] int nResultSamples,
                 IntPtr handle);
@@ -248,6 +258,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSmoothToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial int SmoothToneCurve_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double lambda);
@@ -265,6 +276,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMultisegment")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial int IsToneCurveMultisegment_Internal(
                 IntPtr handle);
 #else
@@ -280,6 +292,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveLinear")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial int IsToneCurveLinear_Internal(
                 IntPtr handle);
 #else
@@ -295,6 +308,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveMonotonic")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial int IsToneCurveMonotonic_Internal(
                 IntPtr handle);
 #else
@@ -310,6 +324,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsIsToneCurveDescending")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial int IsToneCurveDescending_Internal(
                 IntPtr handle);
 #else
@@ -325,6 +340,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsEstimateGamma")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial double EstimateGamma_Internal(
                 IntPtr handle,
                 [MarshalAs(UnmanagedType.R8)] double precision);
@@ -342,6 +358,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTableEntries")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial uint GetToneCurveEstimatedTableEntries_Internal(
                 IntPtr handle);
 #else
@@ -357,6 +374,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetToneCurveEstimatedTable")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial IntPtr GetToneCurveEstimatedTable_Internal(
                 IntPtr handle);
 #else
@@ -372,6 +390,7 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsFreeToneCurve")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
         private static partial void FreeToneCurve_Internal(IntPtr handle);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsFreeToneCurve", CallingConvention = CallingConvention.StdCall)]

--- a/src/lcmsNET/Interop/Interop.Transform.cs
+++ b/src/lcmsNET/Interop/Interop.Transform.cs
@@ -25,6 +25,17 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateTransform_Internal(
+                IntPtr inputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                IntPtr outputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateTransform", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateTransform_Internal(
                 IntPtr inputProfile,
@@ -33,6 +44,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateTransform(IntPtr inputProfile, uint inputFormat,
                 IntPtr outputProfile, uint outputFormat, uint intent, uint flags)
@@ -40,6 +52,18 @@ namespace lcmsNET
             return CreateTransform_Internal(inputProfile, inputFormat, outputProfile, outputFormat, intent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateTransformTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateTransformTHR_Internal(
+                IntPtr contextID,
+                IntPtr inputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                IntPtr outputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateTransformTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateTransformTHR_Internal(
                 IntPtr contextID,
@@ -49,6 +73,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateTransform(IntPtr contextID, IntPtr inputProfile, uint inputFormat,
                 IntPtr outputProfile, uint outputFormat, uint intent, uint flags)
@@ -56,6 +81,19 @@ namespace lcmsNET
             return CreateTransformTHR_Internal(contextID, inputProfile, inputFormat, outputProfile, outputFormat, intent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateProofingTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateProofingTransform_Internal(
+                IntPtr inputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                IntPtr outputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                IntPtr proofingProfile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint proofingIntent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateProofingTransform", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateProofingTransform_Internal(
                 IntPtr inputProfile,
@@ -66,6 +104,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint proofingIntent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateTransform(IntPtr inputProfile, uint inputFormat,
                 IntPtr outputProfile, uint outputFormat, IntPtr proofingProfile, uint intent, uint proofingIntent, uint flags)
@@ -74,6 +113,20 @@ namespace lcmsNET
                     proofingProfile, intent, proofingIntent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateProofingTransformTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateProofingTransformTHR_Internal(
+                IntPtr contextID,
+                IntPtr inputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                IntPtr outputProfile,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                IntPtr proofingProfile,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint proofingIntent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateProofingTransformTHR", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateProofingTransformTHR_Internal(
                 IntPtr contextID,
@@ -85,6 +138,7 @@ namespace lcmsNET
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint proofingIntent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateTransform(IntPtr contextID, IntPtr inputProfile, uint inputFormat,
                 IntPtr outputProfile, uint outputFormat, IntPtr proofingProfile, uint intent, uint proofingIntent, uint flags)
@@ -93,78 +147,135 @@ namespace lcmsNET
                     proofingProfile, intent, proofingIntent, flags);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransform", CallingConvention = CallingConvention.StdCall)]
-        private static extern IntPtr CreateMultiprofileTransform_Internal(
-                IntPtr[] profiles,
-                [MarshalAs(UnmanagedType.U4)] int nProfiles,
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateMultiprofileTransform_Internal(
+                [In] IntPtr[] profiles,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
                 [MarshalAs(UnmanagedType.U4)] uint inputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransform", CallingConvention = CallingConvention.StdCall)]
+        private static extern IntPtr CreateMultiprofileTransform_Internal(
+                IntPtr[] profiles,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateMultiprofileTransform(IntPtr[] profiles, uint inputFormat,
                 uint outputFormat, uint intent, uint flags)
         {
-            return CreateMultiprofileTransform_Internal(profiles, profiles.Length, inputFormat, outputFormat, intent, flags);
+            return CreateMultiprofileTransform_Internal(profiles, (uint)profiles.Length, inputFormat, outputFormat, intent, flags);
         }
 
-        [DllImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransformTHR", CallingConvention = CallingConvention.StdCall)]
-        private static extern IntPtr CreateMultiprofileTransformTHR_Internal(
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransformTHR")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateMultiprofileTransformTHR_Internal(
                 IntPtr contextID,
-                IntPtr[] profiles,
-                [MarshalAs(UnmanagedType.U4)] int nProfiles,
+                [In] IntPtr[] profiles,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
                 [MarshalAs(UnmanagedType.U4)] uint inputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint intent,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
+        [DllImport(Liblcms, EntryPoint = "cmsCreateMultiprofileTransformTHR", CallingConvention = CallingConvention.StdCall)]
+        private static extern IntPtr CreateMultiprofileTransformTHR_Internal(
+                IntPtr contextID,
+                IntPtr[] profiles,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint intent,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateMultiprofileTransform(IntPtr contextID, IntPtr[] profiles, uint inputFormat,
                 uint outputFormat, uint intent, uint flags)
         {
-            return CreateMultiprofileTransformTHR_Internal(contextID, profiles, profiles.Length, inputFormat, outputFormat, intent, flags);
+            return CreateMultiprofileTransformTHR_Internal(contextID, profiles, (uint)profiles.Length, inputFormat, outputFormat, intent, flags);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsCreateExtendedTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr CreateExtendedTransform_Internal(
+                IntPtr contextID,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
+                [In] IntPtr[] profiles,
+                [In] int[] BPC,
+                [In] uint[] intents,
+                [In] double[] adaptationStates,
+                IntPtr gamutProfile,
+                [MarshalAs(UnmanagedType.U4)] uint gamutPcsPosition,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint flags);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsCreateExtendedTransform", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr CreateExtendedTransform_Internal(
                 IntPtr contextID,
-                [MarshalAs(UnmanagedType.U4)] int nProfiles,
+                [MarshalAs(UnmanagedType.U4)] uint nProfiles,
                 IntPtr[] profiles,
                 int[] BPC,
                 uint[] intents,
                 double[] adaptationStates,
                 IntPtr gamutProfile,
-                [MarshalAs(UnmanagedType.U4)] int gamutPcsPosition,
+                [MarshalAs(UnmanagedType.U4)] uint gamutPcsPosition,
                 [MarshalAs(UnmanagedType.U4)] uint inputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint flags);
+#endif
 
         internal static IntPtr CreateExtendedTransform(IntPtr contextID, IntPtr[] profiles, int[] bpc, uint[] intents,
                 double[] adaptationStates, IntPtr gamutProfile, int gamutPcsPosition, uint inputFormat, uint outputFormat, uint flags)
         {
-            return CreateExtendedTransform_Internal(contextID, profiles.Length, profiles, bpc, intents, adaptationStates,
-                    gamutProfile, gamutPcsPosition, inputFormat, outputFormat, flags);
+            return CreateExtendedTransform_Internal(contextID, (uint)profiles.Length, profiles, bpc, intents, adaptationStates,
+                    gamutProfile, (uint)gamutPcsPosition, inputFormat, outputFormat, flags);
         }
 
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDeleteTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void DeleteTransform_Internal(IntPtr transform);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDeleteTransform", CallingConvention = CallingConvention.StdCall)]
         private static extern void DeleteTransform_Internal(IntPtr transform);
+#endif
 
         internal static void DeleteTransform(IntPtr handle)
         {
             DeleteTransform_Internal(handle);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDoTransform")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial void DoTransform_Internal(IntPtr transform,
+                /*const*/ void* inputBuffer,
+                void* outputBuffer,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDoTransform", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void DoTransform_Internal(IntPtr transform,
                 /*const*/ void* inputBuffer,
                 void* outputBuffer,
-                [MarshalAs(UnmanagedType.U4)] int size);
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal unsafe static void DoTransform(IntPtr transform, byte[] inputBuffer, byte[] outputBuffer, int pixelCount)
         {
             fixed (void* pInBuffer = &inputBuffer[0], pOutBuffer = &outputBuffer[0])
             {
-                DoTransform_Internal(transform, pInBuffer, pOutBuffer, pixelCount);
+                DoTransform_Internal(transform, pInBuffer, pOutBuffer, (uint)pixelCount);
             }
         }
 
@@ -172,29 +283,44 @@ namespace lcmsNET
         {
             fixed (void* pInBuffer = inputBuffer, pOutBuffer = outputBuffer)
             {
-                DoTransform_Internal(transform, pInBuffer, pOutBuffer, pixelCount);
+                DoTransform_Internal(transform, pInBuffer, pOutBuffer, (uint)pixelCount);
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsDoTransformLineStride")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial void DoTransformLineStride_Internal(IntPtr transform,
+                /*const*/ void* inputBuffer,
+                void* outputBuffer,
+                [MarshalAs(UnmanagedType.U4)] uint pixelsPerLine,
+                [MarshalAs(UnmanagedType.U4)] uint lineCount,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerLineIn,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerLineOut,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerPlaneIn,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerPlaneOut
+            );
+#else
         [DllImport(Liblcms, EntryPoint = "cmsDoTransformLineStride", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void DoTransformLineStride_Internal(IntPtr transform,
                 /*const*/ void* inputBuffer,
                 void* outputBuffer,
-                [MarshalAs(UnmanagedType.U4)] int pixelsPerLine,
-                [MarshalAs(UnmanagedType.U4)] int lineCount,
-                [MarshalAs(UnmanagedType.U4)] int bytesPerLineIn,
-                [MarshalAs(UnmanagedType.U4)] int bytesPerLineOut,
-                [MarshalAs(UnmanagedType.U4)] int bytesPerPlaneIn,
-                [MarshalAs(UnmanagedType.U4)] int bytesPerPlaneOut
+                [MarshalAs(UnmanagedType.U4)] uint pixelsPerLine,
+                [MarshalAs(UnmanagedType.U4)] uint lineCount,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerLineIn,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerLineOut,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerPlaneIn,
+                [MarshalAs(UnmanagedType.U4)] uint bytesPerPlaneOut
             );
+#endif
 
         internal unsafe static void DoTransform(IntPtr transform, byte[] inputBuffer, byte[] outputBuffer,
                 int pixelsPerLine, int lineCount, int bytesPerLineIn, int bytesPerLineOut, int bytesPerPlaneIn, int bytesPerPlaneOut)
         {
             fixed (void* pInBuffer = &inputBuffer[0], pOutBuffer = &outputBuffer[0])
             {
-                DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, pixelsPerLine, lineCount,
-                        bytesPerLineIn, bytesPerLineOut, bytesPerPlaneIn, bytesPerPlaneOut);
+                DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, (uint)pixelsPerLine, (uint)lineCount,
+                        (uint)bytesPerLineIn, (uint)bytesPerLineOut, (uint)bytesPerPlaneIn, (uint)bytesPerPlaneOut);
             }
         }
 
@@ -203,63 +329,109 @@ namespace lcmsNET
         {
             fixed (void* pInBuffer = inputBuffer, pOutBuffer = outputBuffer)
             {
-                DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, pixelsPerLine, lineCount,
-                        bytesPerLineIn, bytesPerLineOut, bytesPerPlaneIn, bytesPerPlaneOut);
+                DoTransformLineStride_Internal(transform, pInBuffer, pOutBuffer, (uint)pixelsPerLine, (uint)lineCount,
+                        (uint)bytesPerLineIn, (uint)bytesPerLineOut, (uint)bytesPerPlaneIn, (uint)bytesPerPlaneOut);
             }
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetTransformInputFormat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetTransformInputFormat_Internal(
+                IntPtr transform);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetTransformInputFormat", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetTransformInputFormat_Internal(
                 IntPtr transform);
+#endif
 
         internal static uint GetTransformInputFormat(IntPtr transform)
         {
             return GetTransformInputFormat_Internal(transform);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetTransformOutputFormat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetTransformOutputFormat_Internal(
+                IntPtr transform);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetTransformOutputFormat", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetTransformOutputFormat_Internal(
                 IntPtr transform);
+#endif
 
         internal static uint GetTransformOutputFormat(IntPtr transform)
         {
             return GetTransformOutputFormat_Internal(transform);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsChangeBuffersFormat")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int ChangeBuffersFormat_Internal(
+                IntPtr transform,
+                [MarshalAs(UnmanagedType.U4)] uint inputFormat,
+                [MarshalAs(UnmanagedType.U4)] uint outputFormat);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsChangeBuffersFormat", CallingConvention = CallingConvention.StdCall)]
         private static extern int ChangeBuffersFormat_Internal(
                 IntPtr transform,
                 [MarshalAs(UnmanagedType.U4)] uint inputFormat,
                 [MarshalAs(UnmanagedType.U4)] uint outputFormat);
+#endif
 
         internal static int ChangeBuffersFormat(IntPtr transform, uint inputFormat, uint outputFormat)
         {
             return ChangeBuffersFormat_Internal(transform, inputFormat, outputFormat);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsGetTransformUserData")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial IntPtr GetTransformUserData_Internal(
+                IntPtr transform);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsGetTransformUserData", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr GetTransformUserData_Internal(
                 IntPtr transform);
+#endif
 
         internal static IntPtr GetTransformUserData(IntPtr transform)
         {
             return GetTransformUserData_Internal(transform);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsSetTransformUserData")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void SetTransformUserData_Internal(
+                IntPtr transform,
+                IntPtr userData,
+                FreeUserData fn);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsSetTransformUserData", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetTransformUserData_Internal(
                 IntPtr transform,
                 IntPtr userData,
                 FreeUserData fn);
+#endif
 
         internal static void SetTransformUserData(IntPtr transform, IntPtr userData, FreeUserData fn)
         {
             SetTransformUserData_Internal(transform, userData, fn);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsGetTransformFlags")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial uint GetTransformFlags_Internal(
+                IntPtr transform);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsGetTransformFlags", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetTransformFlags_Internal(
                 IntPtr transform);
+#endif
 
         internal static uint GetTransformFlags(IntPtr transform)
         {

--- a/src/lcmsNET/Interop/Interop.cs
+++ b/src/lcmsNET/Interop/Interop.cs
@@ -43,11 +43,11 @@ namespace lcmsNET
 
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandler")]
-        private static partial int SetLogErrorHandler_Internal(
+        private static partial void SetLogErrorHandler_Internal(
                 IntPtr fn);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsSetLogErrorHandler", CallingConvention = CallingConvention.StdCall)]
-        private static extern int SetLogErrorHandler_Internal(
+        private static extern void SetLogErrorHandler_Internal(
                 IntPtr fn);
 #endif
 
@@ -105,11 +105,11 @@ namespace lcmsNET
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodes")]
         private static partial void GetAlarmCodes_Internal(
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [Out] ushort[] alarmCodes);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsGetAlarmCodes", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetAlarmCodes_Internal(
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [Out] ushort[] alarmCodes);
 #endif
 
         internal static void GetAlarmCodes(ushort[] alarmCodes)
@@ -200,7 +200,7 @@ namespace lcmsNET
             // get intent count first
             uint count = GetSupportedIntents_Internal(0, IntPtr.Zero, IntPtr.Zero);
 
-            List<(uint code, string description)> result = new List<(uint code, string description)>();
+            List<(uint code, string description)> result = [];
 
             unsafe
             {

--- a/src/lcmsNET/Interop/Interop.cs
+++ b/src/lcmsNET/Interop/Interop.cs
@@ -28,17 +28,28 @@ namespace lcmsNET
     {
         internal const string Liblcms = "lcms2";
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetEncodedCMMversion")]
+        private static partial int GetEncodedCMMVersion_Internal();
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetEncodedCMMversion", CallingConvention = CallingConvention.StdCall)]
         private static extern int GetEncodedCMMVersion_Internal();
+#endif
 
         internal static int GetEncodedCMMVersion()
         {
             return GetEncodedCMMVersion_Internal();
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandler")]
+        private static partial int SetLogErrorHandler_Internal(
+                IntPtr fn);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetLogErrorHandler", CallingConvention = CallingConvention.StdCall)]
         private static extern int SetLogErrorHandler_Internal(
                 IntPtr fn);
+#endif
 
         internal static void SetErrorHandler(ErrorHandler handler)
         {
@@ -46,85 +57,143 @@ namespace lcmsNET
             SetLogErrorHandler_Internal(fn);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsLCMScolorSpace")]
+        private static partial int LCMSColorSpace_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint iccColorSpaceSignature);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsLCMScolorSpace", CallingConvention = CallingConvention.StdCall)]
         private static extern int LCMSColorSpace_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint iccColorSpaceSignature);
+#endif
 
         internal static int GetLCMSColorSpace(uint iccColorSpaceSignature)
         {
             return LCMSColorSpace_Internal(iccColorSpaceSignature);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsICCcolorSpace")]
+        private static partial int ICCColorSpace_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint lcmsColorSpaceSignature);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsICCcolorSpace", CallingConvention = CallingConvention.StdCall)]
         private static extern int ICCColorSpace_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint lcmsColorSpaceSignature);
+#endif
 
         internal static int GetICCColorSpace(uint lcmsColorSpaceSignature)
         {
             return ICCColorSpace_Internal(lcmsColorSpaceSignature);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsChannelsOf")]
+        private static partial uint ChannelsOf_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint colorSpace);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsChannelsOf", CallingConvention = CallingConvention.StdCall)]
         private static extern uint ChannelsOf_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint colorSpace);
+#endif
 
         internal static uint ChannelsOf(uint colorSpace)
         {
             return ChannelsOf_Internal(colorSpace);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodes")]
+        private static partial void GetAlarmCodes_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetAlarmCodes", CallingConvention = CallingConvention.StdCall)]
         private static extern void GetAlarmCodes_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#endif
 
         internal static void GetAlarmCodes(ushort[] alarmCodes)
         {
             GetAlarmCodes_Internal(alarmCodes);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodes")]
+        private static partial void SetAlarmCodes_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetAlarmCodes", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetAlarmCodes_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+#endif
 
         internal static void SetAlarmCodes(ushort[] alarmCodes)
         {
             SetAlarmCodes_Internal(alarmCodes);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsSetAdaptationState")]
+        private static partial double SetAdaptationState_Internal(
+                [MarshalAs(UnmanagedType.R8)] double adaptationState);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsSetAdaptationState", CallingConvention = CallingConvention.StdCall)]
         private static extern double SetAdaptationState_Internal(
                 [MarshalAs(UnmanagedType.R8)] double adaptationState);
+#endif
 
         internal static double SetAdaptationState(double adaptationState)
         {
             return SetAdaptationState_Internal(adaptationState);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsWhitePointFromTemp")]
+        private static partial double WhitePointFromTemp_Internal(
+                out CIExyY xyY,
+                [MarshalAs(UnmanagedType.R8)] double tempK);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsWhitePointFromTemp", CallingConvention = CallingConvention.StdCall)]
         private static extern double WhitePointFromTemp_Internal(
                 out CIExyY xyY,
                 [MarshalAs(UnmanagedType.R8)] double tempK);
+#endif
 
         internal static double WhitePointFromTemp(out CIExyY xyY, double tempK)
         {
             return WhitePointFromTemp_Internal(out xyY, tempK);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsTempFromWhitePoint")]
+        private static partial double TempFromWhitePoint_Internal(
+                [MarshalAs(UnmanagedType.R8)] out double tempK,
+                in CIExyY xyY);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsTempFromWhitePoint", CallingConvention = CallingConvention.StdCall)]
         private static extern double TempFromWhitePoint_Internal(
                 [MarshalAs(UnmanagedType.R8)] out double tempK,
                 in CIExyY xyY);
+#endif
 
         internal static double TempFromWhitePoint(out double tempK, in CIExyY xyY)
         {
             return TempFromWhitePoint_Internal(out tempK, xyY);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsGetSupportedIntents")]
+        private static partial uint GetSupportedIntents_Internal(
+                [MarshalAs(UnmanagedType.U4)] uint nMax,
+                IntPtr Codes,
+                IntPtr Descriptions);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsGetSupportedIntents", CallingConvention = CallingConvention.StdCall)]
         private static extern uint GetSupportedIntents_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint nMax,
                 IntPtr Codes,
                 IntPtr Descriptions);
+#endif
 
         internal static IEnumerable<(uint code, string description)> GetSupportedIntents()
         {

--- a/src/lcmsNET/Interop/Interop.cs
+++ b/src/lcmsNET/Interop/Interop.cs
@@ -120,11 +120,11 @@ namespace lcmsNET
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodes")]
         private static partial void SetAlarmCodes_Internal(
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [In] ushort[] alarmCodes);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsSetAlarmCodes", CallingConvention = CallingConvention.StdCall)]
         private static extern void SetAlarmCodes_Internal(
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] [In] ushort[] alarmCodes);
 #endif
 
         internal static void SetAlarmCodes(ushort[] alarmCodes)

--- a/src/lcmsNET/Interop/Interop.cs
+++ b/src/lcmsNET/Interop/Interop.cs
@@ -28,7 +28,7 @@ namespace lcmsNET
     {
         internal const string Liblcms = "lcms2";
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetEncodedCMMversion")]
         private static partial int GetEncodedCMMVersion_Internal();
 #else
@@ -41,7 +41,7 @@ namespace lcmsNET
             return GetEncodedCMMVersion_Internal();
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetLogErrorHandler")]
         private static partial int SetLogErrorHandler_Internal(
                 IntPtr fn);
@@ -57,7 +57,7 @@ namespace lcmsNET
             SetLogErrorHandler_Internal(fn);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsLCMScolorSpace")]
         private static partial int LCMSColorSpace_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint iccColorSpaceSignature);
@@ -72,7 +72,7 @@ namespace lcmsNET
             return LCMSColorSpace_Internal(iccColorSpaceSignature);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsICCcolorSpace")]
         private static partial int ICCColorSpace_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint lcmsColorSpaceSignature);
@@ -87,7 +87,7 @@ namespace lcmsNET
             return ICCColorSpace_Internal(lcmsColorSpaceSignature);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsChannelsOf")]
         private static partial uint ChannelsOf_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint colorSpace);
@@ -102,7 +102,7 @@ namespace lcmsNET
             return ChannelsOf_Internal(colorSpace);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetAlarmCodes")]
         private static partial void GetAlarmCodes_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
@@ -117,7 +117,7 @@ namespace lcmsNET
             GetAlarmCodes_Internal(alarmCodes);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAlarmCodes")]
         private static partial void SetAlarmCodes_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U2, SizeConst = 16)] ushort[] alarmCodes);
@@ -132,7 +132,7 @@ namespace lcmsNET
             SetAlarmCodes_Internal(alarmCodes);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsSetAdaptationState")]
         private static partial double SetAdaptationState_Internal(
                 [MarshalAs(UnmanagedType.R8)] double adaptationState);
@@ -147,7 +147,7 @@ namespace lcmsNET
             return SetAdaptationState_Internal(adaptationState);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsWhitePointFromTemp")]
         private static partial double WhitePointFromTemp_Internal(
                 out CIExyY xyY,
@@ -164,7 +164,7 @@ namespace lcmsNET
             return WhitePointFromTemp_Internal(out xyY, tempK);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsTempFromWhitePoint")]
         private static partial double TempFromWhitePoint_Internal(
                 [MarshalAs(UnmanagedType.R8)] out double tempK,
@@ -181,7 +181,7 @@ namespace lcmsNET
             return TempFromWhitePoint_Internal(out tempK, xyY);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsGetSupportedIntents")]
         private static partial uint GetSupportedIntents_Internal(
                 [MarshalAs(UnmanagedType.U4)] uint nMax,

--- a/src/lcmsNET/Interop/Plugin/Interop.DateTimeNumber.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.DateTimeNumber.cs
@@ -24,16 +24,36 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsEncodeDateTimeNumber")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void EncodeDateTimeNumber_Internal(
+                ref DateTimeNumber d,
+                in Tm tm);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsEncodeDateTimeNumber", CallingConvention = CallingConvention.StdCall)]
         private static extern void EncodeDateTimeNumber_Internal(
                 ref DateTimeNumber d,
                 in Tm tm);
+#endif
 
         internal static void EncodeDateTimeNumber(ref DateTimeNumber d, in Tm tm)
         {
             EncodeDateTimeNumber_Internal(ref d, in tm);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsDecodeDateTimeNumber")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void DecodeDateTimeNumber_Internal(
+                in DateTimeNumber d,
+                ref Tm tm);
+
+        internal static void DecodeDateTimeNumber(in DateTimeNumber d, ref Tm tm)
+        {
+            DecodeDateTimeNumber_Internal(in d, ref tm);
+        }
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsDecodeDateTimeNumber", CallingConvention = CallingConvention.StdCall)]
         private static extern void DecodeDateTimeNumber_Internal(
                 in DateTimeNumber d,
@@ -43,5 +63,6 @@ namespace lcmsNET
         {
             DecodeDateTimeNumber_Internal(in d, ref tm);
         }
+#endif
     }
 }

--- a/src/lcmsNET/Interop/Plugin/Interop.FixedPoint.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.FixedPoint.cs
@@ -24,36 +24,64 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cms8Fixed8toDouble")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double Fixed8Dot8ToDouble_Internal(
+                [MarshalAs(UnmanagedType.U2)] ushort fixed8);
+#else
         [DllImport(Liblcms, EntryPoint = "_cms8Fixed8toDouble", CallingConvention = CallingConvention.StdCall)]
         private static extern double Fixed8Dot8ToDouble_Internal(
                 [MarshalAs(UnmanagedType.U2)] ushort fixed8);
+#endif
 
         internal static double Fixed8Dot8ToDouble(ushort fixed8)
         {
             return Fixed8Dot8ToDouble_Internal(fixed8);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsDoubleTo8Fixed8")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial ushort DoubleToFixed8Dot8_Internal(
+                [MarshalAs(UnmanagedType.R8)] double val);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsDoubleTo8Fixed8", CallingConvention = CallingConvention.StdCall)]
         private static extern ushort DoubleToFixed8Dot8_Internal(
                 [MarshalAs(UnmanagedType.R8)] double val);
+#endif
 
         internal static ushort DoubleToFixed8Dot8(double val)
         {
             return DoubleToFixed8Dot8_Internal(val);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cms15Fixed16toDouble")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double Fixed15Dot16ToDouble_Internal(
+                [MarshalAs(UnmanagedType.I4)] int fixed32);
+#else
         [DllImport(Liblcms, EntryPoint = "_cms15Fixed16toDouble", CallingConvention = CallingConvention.StdCall)]
         private static extern double Fixed15Dot16ToDouble_Internal(
                 [MarshalAs(UnmanagedType.I4)] int fixed32);
+#endif
 
         internal static double Fixed15Dot16ToDouble(int fixed32)
         {
             return Fixed15Dot16ToDouble_Internal(fixed32);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsDoubleTo15Fixed16")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int DoubleToFixed15Dot16_Internal(
+                [MarshalAs(UnmanagedType.R8)] double val);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsDoubleTo15Fixed16", CallingConvention = CallingConvention.StdCall)]
         private static extern int DoubleToFixed15Dot16_Internal(
                 [MarshalAs(UnmanagedType.R8)] double val);
+#endif
 
         internal static int DoubleToFixed15Dot16(double val)
         {

--- a/src/lcmsNET/Interop/Plugin/Interop.MAT3.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.MAT3.cs
@@ -25,61 +25,110 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3identity")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void MAT3identity_Internal(
+                ref MAT3 a);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3identity", CallingConvention = CallingConvention.StdCall)]
         private static extern void MAT3identity_Internal(
                 ref MAT3 a);
+#endif
 
         internal static void MAT3identity(ref MAT3 a)
         {
             MAT3identity_Internal(ref a);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3isIdentity")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MAT3isIdentity_Internal(
+                in MAT3 a);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3isIdentity", CallingConvention = CallingConvention.StdCall)]
         private static extern int MAT3isIdentity_Internal(
                 in MAT3 a);
+#endif
 
         internal static bool MAT3isIdentity(in MAT3 a)
         {
             return MAT3isIdentity_Internal(in a) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3per")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void MAT3per_Internal(
+                ref MAT3 r,
+                in MAT3 a,
+                in MAT3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3per", CallingConvention = CallingConvention.StdCall)]
         private static extern void MAT3per_Internal(
                 ref MAT3 r,
                 in MAT3 a,
                 in MAT3 b);
+#endif
 
         internal static void MAT3multiply(ref MAT3 r, in MAT3 a, in MAT3 b)
         {
             MAT3per_Internal(ref r, in a, in b);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3inverse")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MAT3inverse_Internal(
+                in MAT3 a,
+                ref MAT3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3inverse", CallingConvention = CallingConvention.StdCall)]
         private static extern int MAT3inverse_Internal(
                 in MAT3 a,
                 ref MAT3 b);
+#endif
 
         internal static bool MAT3invert(in MAT3 a, ref MAT3 b)
         {
             return MAT3inverse_Internal(in a, ref b) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3solve")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MAT3solve_Internal(
+                ref VEC3 x,
+                in MAT3 a,
+                in VEC3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3solve", CallingConvention = CallingConvention.StdCall)]
         private static extern int MAT3solve_Internal(
                 ref VEC3 x,
                 in MAT3 a,
                 in VEC3 b);
+#endif
 
         internal static bool MAT3solve(ref VEC3 x, in MAT3 a, in VEC3 b)
         {
             return MAT3solve_Internal(ref x, in a, in b) != 0;
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMAT3eval")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial int MAT3eval_Internal(
+                ref VEC3 r,
+                in MAT3 a,
+                in VEC3 v);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMAT3eval", CallingConvention = CallingConvention.StdCall)]
         private static extern int MAT3eval_Internal(
                 ref VEC3 r,
                 in MAT3 a,
                 in VEC3 v);
+#endif
 
         internal static bool MAT3eval(ref VEC3 r, in MAT3 a, in VEC3 v)
         {

--- a/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
@@ -25,7 +25,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsMD5alloc")]
         private static partial IntPtr MD5alloc_Internal(
                 IntPtr contextID);
@@ -55,7 +55,7 @@ namespace lcmsNET
             }
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsMD5finish")]
         private static partial void MD5Finish_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID,

--- a/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
@@ -66,7 +66,7 @@ namespace lcmsNET
 #if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "cmsMD5finish")]
         private static partial void MD5Finish_Internal(
-                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID,
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] [Out] byte[] profileID,
                 IntPtr handle);
 #else
         [DllImport(Liblcms, EntryPoint = "cmsMD5finish", CallingConvention = CallingConvention.StdCall)]

--- a/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
@@ -40,18 +40,26 @@ namespace lcmsNET
             return MD5alloc_Internal(contextID);
         }
 
-        // Keep DllImport for this signature to avoid SYSLIB1052 and source-generated duplicates.
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "cmsMD5add")]
+        [UnmanagedCallConv(CallConvs = new Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static unsafe partial void MD5Add_Internal(
+                IntPtr handle,
+                /*const*/ void* memPtr,
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMD5add", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void MD5Add_Internal(
                 IntPtr handle,
                 /*const*/ void* memPtr,
-                [MarshalAs(UnmanagedType.U4)] int memSize);
+                [MarshalAs(UnmanagedType.U4)] uint memSize);
+#endif
 
         internal unsafe static void MD5Add(IntPtr md5, byte[] memory)
         {
             fixed (void* memPtr = &memory[0])
             {
-                MD5Add_Internal(md5, memPtr, memory.Length);
+                MD5Add_Internal(md5, memPtr, (uint)memory.Length);
             }
         }
 

--- a/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.MD5.cs
@@ -25,15 +25,22 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsMD5alloc")]
+        private static partial IntPtr MD5alloc_Internal(
+                IntPtr contextID);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMD5alloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr MD5alloc_Internal(
                 IntPtr contextID);
+#endif
 
         internal static IntPtr MD5Alloc(IntPtr contextID)
         {
             return MD5alloc_Internal(contextID);
         }
 
+        // Keep DllImport for this signature to avoid SYSLIB1052 and source-generated duplicates.
         [DllImport(Liblcms, EntryPoint = "cmsMD5add", CallingConvention = CallingConvention.StdCall)]
         private unsafe static extern void MD5Add_Internal(
                 IntPtr handle,
@@ -48,10 +55,17 @@ namespace lcmsNET
             }
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "cmsMD5finish")]
+        private static partial void MD5Finish_Internal(
+                [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID,
+                IntPtr handle);
+#else
         [DllImport(Liblcms, EntryPoint = "cmsMD5finish", CallingConvention = CallingConvention.StdCall)]
         private static extern void MD5Finish_Internal(
                 [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U1, SizeConst = 16)] byte[] profileID,
                 IntPtr handle);
+#endif
 
         internal static void MD5Finish(IntPtr md5, byte[] profileID)
         {

--- a/src/lcmsNET/Interop/Plugin/Interop.Memory.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.Memory.cs
@@ -25,7 +25,7 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsMalloc")]
         private static partial IntPtr Malloc_Internal(
                 IntPtr context,
@@ -42,7 +42,7 @@ namespace lcmsNET
             return Malloc_Internal(context, size);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsFree")]
         private static partial IntPtr Free_Internal(
                 IntPtr context,
@@ -59,7 +59,7 @@ namespace lcmsNET
             return Free_Internal(context, ptr);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsMallocZero")]
         private static partial IntPtr MallocZero_Internal(
                 IntPtr context,
@@ -76,7 +76,7 @@ namespace lcmsNET
             return MallocZero_Internal(context, size);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsCalloc")]
         private static partial IntPtr Calloc_Internal(
                 IntPtr context,
@@ -95,7 +95,7 @@ namespace lcmsNET
             return Calloc_Internal(context, num, size);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsRealloc")]
         private static partial IntPtr Realloc_Internal(
                 IntPtr context,
@@ -114,7 +114,7 @@ namespace lcmsNET
             return Realloc_Internal(context, ptr, size);
         }
 
-#if NET8_0
+#if NET7_0_OR_GREATER
         [LibraryImport(Liblcms, EntryPoint = "_cmsDupMem")]
         private static partial IntPtr DupMem_Internal(
                 IntPtr context,

--- a/src/lcmsNET/Interop/Plugin/Interop.Memory.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.Memory.cs
@@ -25,63 +25,108 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMalloc")]
+        private static partial IntPtr Malloc_Internal(
+                IntPtr context,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMalloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Malloc_Internal(
                 IntPtr context,
                 [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal static IntPtr Malloc(IntPtr context, uint size)
         {
             return Malloc_Internal(context, size);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsFree")]
+        private static partial IntPtr Free_Internal(
+                IntPtr context,
+                IntPtr ptr);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsFree", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Free_Internal(
                 IntPtr context,
                 IntPtr ptr);
+#endif
 
         internal static IntPtr Free(IntPtr context, IntPtr ptr)
         {
             return Free_Internal(context, ptr);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsMallocZero")]
+        private static partial IntPtr MallocZero_Internal(
+                IntPtr context,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsMallocZero", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr MallocZero_Internal(
                 IntPtr context,
                 [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal static IntPtr MallocZero(IntPtr context, uint size)
         {
             return MallocZero_Internal(context, size);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsCalloc")]
+        private static partial IntPtr Calloc_Internal(
+                IntPtr context,
+                [MarshalAs(UnmanagedType.U4)] uint num,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsCalloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Calloc_Internal(
                 IntPtr context,
                 [MarshalAs(UnmanagedType.U4)] uint num,
                 [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal static IntPtr Calloc(IntPtr context, uint num, uint size)
         {
             return Calloc_Internal(context, num, size);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsRealloc")]
+        private static partial IntPtr Realloc_Internal(
+                IntPtr context,
+                IntPtr ptr,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsRealloc", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr Realloc_Internal(
                 IntPtr context,
                 IntPtr ptr,
                 [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal static IntPtr Realloc(IntPtr context, IntPtr ptr, uint size)
         {
             return Realloc_Internal(context, ptr, size);
         }
 
+#if NET8_0
+        [LibraryImport(Liblcms, EntryPoint = "_cmsDupMem")]
+        private static partial IntPtr DupMem_Internal(
+                IntPtr context,
+                IntPtr org,
+                [MarshalAs(UnmanagedType.U4)] uint size);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsDupMem", CallingConvention = CallingConvention.StdCall)]
         private static extern IntPtr DupMem_Internal(
                 IntPtr context,
                 IntPtr org,
                 [MarshalAs(UnmanagedType.U4)] uint size);
+#endif
 
         internal static IntPtr DupMem(IntPtr context, IntPtr org, uint size)
         {

--- a/src/lcmsNET/Interop/Plugin/Interop.VEC3.cs
+++ b/src/lcmsNET/Interop/Plugin/Interop.VEC3.cs
@@ -25,63 +25,114 @@ namespace lcmsNET
 {
     internal static partial class Interop
     {
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3init")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void VEC3init_Internal(
+                ref VEC3 v,
+                [MarshalAs(UnmanagedType.R8)] double x,
+                [MarshalAs(UnmanagedType.R8)] double y,
+                [MarshalAs(UnmanagedType.R8)] double z);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3init", CallingConvention = CallingConvention.StdCall)]
         private static extern void VEC3init_Internal(
                 ref VEC3 v,
                 [MarshalAs(UnmanagedType.R8)] double x,
                 [MarshalAs(UnmanagedType.R8)] double y,
                 [MarshalAs(UnmanagedType.R8)] double z);
+#endif
 
         internal static void VEC3init(ref VEC3 v, double x, double y, double z)
         {
             VEC3init_Internal(ref v, x, y, z);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3minus")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void VEC3minus_Internal(
+                ref VEC3 r,
+                in VEC3 a,
+                in VEC3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3minus", CallingConvention = CallingConvention.StdCall)]
         private static extern void VEC3minus_Internal(
                 ref VEC3 r,
                 in VEC3 a,
                 in VEC3 b);
+#endif
 
         internal static void VEC3minus(ref VEC3 v, in VEC3 a, in VEC3 b)
         {
             VEC3minus_Internal(ref v, a, b);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3cross")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial void VEC3cross_Internal(
+                ref VEC3 r,
+                in VEC3 a,
+                in VEC3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3cross", CallingConvention = CallingConvention.StdCall)]
         private static extern void VEC3cross_Internal(
                 ref VEC3 r,
                 in VEC3 a,
                 in VEC3 b);
+#endif
 
         internal static void VEC3cross(ref VEC3 v, in VEC3 a, in VEC3 b)
         {
             VEC3cross_Internal(ref v, a, b);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3dot")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double VEC3dot_Internal(
+                in VEC3 a,
+                in VEC3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3dot", CallingConvention = CallingConvention.StdCall)]
         private static extern double VEC3dot_Internal(
                 in VEC3 a,
                 in VEC3 b);
+#endif
 
         internal static double VEC3dot(in VEC3 a, in VEC3 b)
         {
             return VEC3dot_Internal(a, b);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3length")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double VEC3length_Internal(
+                in VEC3 a);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3length", CallingConvention = CallingConvention.StdCall)]
         private static extern double VEC3length_Internal(
                 in VEC3 a);
+#endif
 
         internal static double VEC3length(in VEC3 a)
         {
             return VEC3length_Internal(a);
         }
 
+#if NET7_0_OR_GREATER
+        [LibraryImport(Liblcms, EntryPoint = "_cmsVEC3distance")]
+        [UnmanagedCallConv(CallConvs = new System.Type[] { typeof(System.Runtime.CompilerServices.CallConvStdcall) })]
+        private static partial double VEC3distance_Internal(
+                in VEC3 a,
+                in VEC3 b);
+#else
         [DllImport(Liblcms, EntryPoint = "_cmsVEC3distance", CallingConvention = CallingConvention.StdCall)]
         private static extern double VEC3distance_Internal(
                 in VEC3 a,
                 in VEC3 b);
+#endif
 
         internal static double VEC3distance(in VEC3 a, in VEC3 b)
         {

--- a/src/lcmsNET/MHC2.cs
+++ b/src/lcmsNET/MHC2.cs
@@ -29,6 +29,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct MHC2
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<MHC2>
+#endif
     {
         /// <summary>
         /// Number of elements in each 1D LUT.
@@ -67,7 +70,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="MHC2"/> instance.</returns>
-        internal static MHC2 FromHandle(IntPtr handle)
+        public static MHC2 FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<MHC2>(handle);
         }

--- a/src/lcmsNET/MultiLocalizedUnicode.cs
+++ b/src/lcmsNET/MultiLocalizedUnicode.cs
@@ -27,6 +27,9 @@ namespace lcmsNET
     /// Represents a multi-localized Unicode string.
     /// </summary>
     public sealed class MultiLocalizedUnicode : TagBase<MultiLocalizedUnicode>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<MultiLocalizedUnicode>
+#endif
     {
         /// <summary>
         /// The language code for 'no language'.

--- a/src/lcmsNET/NamedColorList.cs
+++ b/src/lcmsNET/NamedColorList.cs
@@ -27,6 +27,9 @@ namespace lcmsNET
     /// Represents a named color list.
     /// </summary>
     public sealed class NamedColorList : TagBase<NamedColorList>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<NamedColorList>
+#endif
     {
         internal NamedColorList(IntPtr handle, Context context = null, bool isOwner = true)
             : base(handle, context, isOwner)
@@ -38,7 +41,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to an existing named color list.</param>
         /// <returns>A new <see cref="NamedColorList"/> instance referencing an existing named color list.</returns>
-        internal static NamedColorList FromHandle(IntPtr handle)
+        public static NamedColorList FromHandle(IntPtr handle)
         {
             return new NamedColorList(handle, context: null, isOwner: false);
         }

--- a/src/lcmsNET/Pipeline.cs
+++ b/src/lcmsNET/Pipeline.cs
@@ -65,6 +65,9 @@ namespace lcmsNET
     /// provides the input to the next and so on through the pipeline.
     /// </summary>
     public sealed class Pipeline : TagBase<Pipeline>, IEnumerable<Stage>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<Pipeline>
+#endif
     {
         internal Pipeline(IntPtr handle, Context context = null, bool isOwner = true)
             : base(handle, context, isOwner)
@@ -290,9 +293,9 @@ namespace lcmsNET
                 double[] adaptationStates, CmsFlags flags)
         {
             return new Pipeline(Interop.DefaultICCIntents(Helper.GetHandle(context),
-                    intents.Select(_ => Convert.ToUInt32(_)).ToArray(),
-                    profiles.Select(_ => Helper.GetHandle(_)).ToArray(),
-                    bpc.Select(_ => _ ? 1 : 0).ToArray(),
+                    [.. intents.Select(_ => Convert.ToUInt32(_))],
+                    [.. profiles.Select(_ => Helper.GetHandle(_))],
+                    [.. bpc.Select(_ => _ ? 1 : 0)],
                     adaptationStates, Convert.ToUInt32(flags)),
                     context);
         }
@@ -360,15 +363,8 @@ namespace lcmsNET
             return GetEnumerator();
         }
 
-        private class StageEnumerator : IEnumerator<Stage>
+        private class StageEnumerator(IntPtr handle) : IEnumerator<Stage>
         {
-            public StageEnumerator(IntPtr handle)
-            {
-                First = GetFirst(handle);
-                Last = GetLast(handle);
-                Location = Position.Before;
-            }
-
             public Stage Current
             {
                 get
@@ -419,20 +415,20 @@ namespace lcmsNET
                 Location = Position.Before;
             }
 
-            private IntPtr First { get; set; }
-            private IntPtr GetFirst(IntPtr handle)
+            private IntPtr First { get; set; } = GetFirst(handle);
+            private static IntPtr GetFirst(IntPtr handle)
             {
                 return Interop.PipelineGetPtrToFirstStage(handle);
             }
 
-            private IntPtr Last { get; set; }
-            private IntPtr GetLast(IntPtr handle)
+            private IntPtr Last { get; set; } = GetLast(handle);
+            private static IntPtr GetLast(IntPtr handle)
             {
                 return Interop.PipelineGetPtrToLastStage(handle);
             }
 
             private enum Position { Before, During, After };
-            private Position Location { get; set; }
+            private Position Location { get; set; } = Position.Before;
 
             public void Dispose()
             {

--- a/src/lcmsNET/Plugin/MAT3.cs
+++ b/src/lcmsNET/Plugin/MAT3.cs
@@ -29,46 +29,29 @@ namespace lcmsNET.Plugin
     [StructLayout(LayoutKind.Sequential)]
     public readonly struct MAT3
     {
-        /// <summary>
-        /// The vector components of the matrix.
-        /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
-        private readonly VEC3[] v;
+        // Make MAT3 blittable for source-generated P/Invoke by using three VEC3 fields
+        // instead of an array field.
+        private readonly VEC3 Row0;
+        private readonly VEC3 Row1;
+        private readonly VEC3 Row2;
+
+        private MAT3(VEC3 row0, VEC3 row1, VEC3 row2)
+        {
+            Row0 = row0;
+            Row1 = row1;
+            Row2 = row2;
+        }
 
         /// <summary>
         /// Initialises a new instance of the <see cref="MAT3"/> class.
         /// </summary>
-        /// <param name="v">An array of 3 <see cref="VEC3"/> instances.</param>
-        public MAT3(VEC3[/*3*/] v)
+        /// <param name="rows">An array of 3 <see cref="VEC3"/> instances.</param>
+        public MAT3(VEC3[] rows)
         {
-            if (v?.Length != 3) throw new ArgumentException($"'{nameof(v)}' array size must equal 3.");
-            this.v = v;
-        }
-
-        /// <summary>
-        /// Creates a zeroes matrix.
-        /// </summary>
-        /// <returns>A new zeroes matrix.</returns>
-        public static MAT3 Zeroes()
-        {
-            return new MAT3(
-                new VEC3[3]
-                {
-                    new VEC3(0, 0, 0),
-                    new VEC3(0, 0, 0),
-                    new VEC3(0, 0, 0)
-                });
-        }
-
-        /// <summary>
-        /// Creates an identity matrix.
-        /// </summary>
-        /// <returns>A new identity matrix.</returns>
-        public static MAT3 Identity()
-        {
-            MAT3 m = Zeroes();
-            Interop.MAT3identity(ref m);
-            return m;
+            if (rows?.Length != 3) throw new ArgumentException($"'{nameof(rows)}' array size must equal 3.");
+            Row0 = rows[0];
+            Row1 = rows[1];
+            Row2 = rows[2];
         }
 
         /// <summary>
@@ -78,8 +61,29 @@ namespace lcmsNET.Plugin
         /// <returns>The vector at the specified index.</returns>
         public VEC3 this[int index]
         {
-            get => v[index];
+            get
+            {
+                return index switch
+                {
+                    0 => Row0,
+                    1 => Row1,
+                    2 => Row2,
+                    _ => throw new IndexOutOfRangeException($"'{nameof(index)}' must be in the range 0 to 2.")
+                };
+            }
         }
+
+        /// <summary>
+        /// Creates a zeroes matrix.
+        /// </summary>
+        /// <returns>A new zeroes matrix.</returns>
+        public static MAT3 Zeroes() => new(default, default, default);
+
+        /// <summary>
+        /// Creates an identity matrix.
+        /// </summary>
+        /// <returns>A new identity matrix.</returns>
+        public static MAT3 Identity() => new(new(1.0, 0.0, 0.0), new(0.0, 1.0, 0.0), new(0.0, 0.0, 1.0));
 
         /// <summary>
         /// Returns true if the matrix is close enough to be interpreted as identity, otherwise returns false.
@@ -94,9 +98,9 @@ namespace lcmsNET.Plugin
         /// <returns>A matrix containing the result of the multiplication.</returns>
         public static MAT3 Multiply(in MAT3 a, in MAT3 b)
         {
-            MAT3 m = Zeroes();
-            Interop.MAT3multiply(ref m, in a, in b);
-            return m;
+            MAT3 r = default;
+            Interop.MAT3multiply(ref r, in a, in b);
+            return r;
         }
 
         /// <summary>
@@ -110,7 +114,7 @@ namespace lcmsNET.Plugin
         /// </remarks>
         public static bool Invert(in MAT3 a, out MAT3 b)
         {
-            b = Zeroes();
+            b = default;
             return Interop.MAT3invert(in a, ref b);
         }
 
@@ -126,7 +130,7 @@ namespace lcmsNET.Plugin
         /// </remarks>
         public static bool Solve(in MAT3 a, in VEC3 b, out VEC3 x)
         {
-            x = new VEC3(0, 0, 0);
+            x = default;
             return Interop.MAT3solve(ref x, in a, in b);
         }
 
@@ -138,7 +142,7 @@ namespace lcmsNET.Plugin
         /// <returns>A vector containing the result of the evaluation.</returns>
         public static VEC3 Evaluate(in MAT3 a, in VEC3 v)
         {
-            VEC3 r = new VEC3(0, 0, 0);
+            VEC3 r = default;
             Interop.MAT3eval(ref r, in a, in v);
             return r;
         }

--- a/src/lcmsNET/Plugin/VEC3.cs
+++ b/src/lcmsNET/Plugin/VEC3.cs
@@ -26,25 +26,18 @@ namespace lcmsNET.Plugin
     /// <summary>
     /// Represents a 3-component vector defined as using double precision floating point numbers.
     /// </summary>
+    /// <remarks>
+    /// Initialises the vector.
+    /// </remarks>
+    /// <param name="x">x component of the vector.</param>
+    /// <param name="y">y component of the vector.</param>
+    /// <param name="z">z component of the vector.</param>
     [StructLayout(LayoutKind.Sequential)]
-    public struct VEC3
+    public struct VEC3(double x, double y, double z)
     {
-        private double X;
-        private double Y;
-        private double Z;
-
-        /// <summary>
-        /// Initialises the vector.
-        /// </summary>
-        /// <param name="x">x component of the vector.</param>
-        /// <param name="y">y component of the vector.</param>
-        /// <param name="z">z component of the vector.</param>
-        public VEC3(double x, double y, double z)
-        {
-            X = x;
-            Y = y;
-            Z = z;
-        }
+        private double X = x;
+        private double Y = y;
+        private double Z = z;
 
         /// <summary>
         /// Gets or sets the value of the vector component at the specified index.
@@ -53,7 +46,7 @@ namespace lcmsNET.Plugin
         /// <returns>The value of vector component at the specified index.</returns>
         public double this[int index]
         {
-            get
+            readonly get
             {
                 return index switch
                 {
@@ -130,7 +123,7 @@ namespace lcmsNET.Plugin
         /// <summary>
         /// Returns the Euclidean length of the vector.
         /// </summary>
-        public double Length
+        public readonly double Length
         {
             get => Math.Sqrt(X * X + Y * Y + Z * Z);
         }

--- a/src/lcmsNET/Plugin/VEC3.cs
+++ b/src/lcmsNET/Plugin/VEC3.cs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace lcmsNET.Plugin
@@ -26,13 +27,11 @@ namespace lcmsNET.Plugin
     /// Represents a 3-component vector defined as using double precision floating point numbers.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public readonly struct VEC3
+    public struct VEC3
     {
-        /// <summary>
-        /// The components of the vector.
-        /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.R8, SizeConst = 3)]
-        private readonly double[] n;
+        private double X;
+        private double Y;
+        private double Z;
 
         /// <summary>
         /// Initialises the vector.
@@ -42,9 +41,9 @@ namespace lcmsNET.Plugin
         /// <param name="z">z component of the vector.</param>
         public VEC3(double x, double y, double z)
         {
-            n = new double[3];
-
-            Interop.VEC3init(ref this, x, y, z);
+            X = x;
+            Y = y;
+            Z = z;
         }
 
         /// <summary>
@@ -54,8 +53,33 @@ namespace lcmsNET.Plugin
         /// <returns>The value of vector component at the specified index.</returns>
         public double this[int index]
         {
-            get => n[index];
-            set => n[index] = value;
+            get
+            {
+                return index switch
+                {
+                    0 => X,
+                    1 => Y,
+                    2 => Z,
+                    _ => throw new IndexOutOfRangeException($"Index must be in the range [0, 2].")
+                };
+            }
+            set
+            {
+                switch (index)
+                {
+                    case 0:
+                        X = value;
+                        break;
+                    case 1:
+                        Y = value;
+                        break;
+                    case 2:
+                        Z = value;
+                        break;
+                    default:
+                        throw new IndexOutOfRangeException($"Index must be in the range [0, 2].");
+                }
+            }
         }
 
         /// <summary>
@@ -68,7 +92,7 @@ namespace lcmsNET.Plugin
         /// </returns>
         public static VEC3 operator -(in VEC3 v1, in VEC3 v2)
         {
-            VEC3 result = new VEC3(0, 0, 0);
+            VEC3 result = new(default, default, default);
             Interop.VEC3minus(ref result, in v1, in v2);
             return result;
         }
@@ -83,9 +107,11 @@ namespace lcmsNET.Plugin
         /// </returns>
         public static VEC3 Cross(in VEC3 v1, in VEC3 v2)
         {
-            VEC3 result = new VEC3(0, 0, 0);
-            Interop.VEC3cross(ref result, in v1, in v2);
-            return result;
+            return new VEC3(
+                v1.Y * v2.Z - v1.Z * v2.Y,
+                v1.Z * v2.X - v1.X * v2.Z,
+                v1.X * v2.Y - v1.Y * v2.X
+            );
         }
 
         /// <summary>
@@ -98,13 +124,16 @@ namespace lcmsNET.Plugin
         /// </returns>
         public static double Dot(in VEC3 v1, in VEC3 v2)
         {
-            return Interop.VEC3dot(in v1, in v2);
+            return v1.X * v2.X + v1.Y * v2.Y + v1.Z * v2.Z;
         }
 
         /// <summary>
         /// Returns the Euclidean length of the vector.
         /// </summary>
-        public double Length => Interop.VEC3length(in this);
+        public double Length
+        {
+            get => Math.Sqrt(X * X + Y * Y + Z * Z);
+        }
 
         /// <summary>
         /// Calculates the Euclidean distance between two vector points.
@@ -114,7 +143,10 @@ namespace lcmsNET.Plugin
         /// <returns>The Euclidean distance between the points.</returns>
         public static double Distance(in VEC3 v1, in VEC3 v2)
         {
-            return Interop.VEC3distance(in v1, in v2);
+            var dx = v1.X - v2.X;
+            var dy = v1.Y - v2.Y;
+            var dz = v1.Z - v2.Z;
+            return Math.Sqrt(dx * dx + dy * dy + dz * dz);
         }
     }
 }

--- a/src/lcmsNET/Profile.cs
+++ b/src/lcmsNET/Profile.cs
@@ -21,11 +21,42 @@
 using lcmsNET.Impl;
 using System;
 using System.Linq;
+#if NETSTANDARD2_0_OR_GREATER
 using System.Reflection;
+#endif
 using System.Runtime.InteropServices;
 
 namespace lcmsNET
 {
+#if NET7_0_OR_GREATER
+    /// <summary>
+    /// Defines an interface for types that can be created from a handle to an existing object.
+    /// </summary>
+    /// <typeparam name="T">The type of the instance to create.</typeparam>
+    public interface ICreatableFromHandle<out T>
+    {
+        /// <summary>
+        /// Creates an instance of T that represents the specified native handle.
+        /// </summary>
+        /// <param name="handle">A native handle that identifies the underlying resource; must be a valid handle for the implementation.</param>
+        /// <returns>An instance of T that wraps the provided native handle.</returns>
+        static abstract T FromHandle(IntPtr handle);
+    }
+
+    /// <summary>
+    /// Represents a type that can produce a native handle for use by underlying native or platform-specific
+    /// implementations.
+    /// </summary>
+    public interface IHandleConvertible
+    {
+        /// <summary>
+        /// Converts the current instance to a native handle that can be used by the underlying implementation.
+        /// </summary>
+        /// <returns>A native handle that represents the current instance.</returns>
+        IntPtr ToHandle();
+    }
+#endif
+
     /// <summary>
     /// Represents an International Color Consortium Profile.
     /// </summary>
@@ -852,18 +883,25 @@ namespace lcmsNET
         /// The Profile has already been disposed.
         /// </exception>
         public T ReadTag<T>(TagSignature tag)
+#if NET7_0_OR_GREATER
+            where T: ICreatableFromHandle<T>
+#endif
         {
             EnsureNotClosed();
 
             IntPtr ptr = ReadTag(tag);
             Helper.CheckCreated<T>(ptr);
 
+#if NET7_0_OR_GREATER
+            return T.FromHandle(ptr);
+#else
             Type t = typeof(T);
             MethodInfo method = t.GetMethod("FromHandle", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static,
                     null, [typeof(IntPtr)], null);
             return method is null
                 ? throw new MissingMethodException(nameof(T), "FromHandle(IntPtr)")
                 : (T)method.Invoke(null, [ptr]);
+#endif
         }
 
         /// <summary>
@@ -958,13 +996,21 @@ namespace lcmsNET
         }
 
         private bool WriteTag<T>(TagSignature tag, T t)
+#if NET7_0_OR_GREATER
+            where T: class, IHandleConvertible
+#else
             where T: class
+#endif
         {
             EnsureNotClosed();
 
+#if NET7_0_OR_GREATER
+            IntPtr ptr = t.ToHandle();
+#else
             MethodInfo method = typeof(T).GetMethod("ToHandle", BindingFlags.NonPublic | BindingFlags.Instance,
                     null, [], null) ?? throw new MissingMethodException(nameof(T), "ToHandle()");
             IntPtr ptr = (IntPtr)method.Invoke(t, []);
+#endif
             try
             {
                 return WriteTag(tag, ptr);
@@ -1012,7 +1058,7 @@ namespace lcmsNET
 
             return (TagSignature)Interop.TagLinkedTo(handle, Convert.ToUInt32(tag));
         }
-        #endregion
+#endregion
 
         #region Intents
         /// <summary>

--- a/src/lcmsNET/Profile.cs
+++ b/src/lcmsNET/Profile.cs
@@ -91,7 +91,7 @@ namespace lcmsNET
         {
             if (transferFunction?.Length != 3) throw new ArgumentException($"'{nameof(transferFunction)}' array size must equal 3.");
 
-            return new Profile(Interop.CreateRGB(whitePoint, primaries, transferFunction.Select(_ => _.Handle).ToArray()));
+            return new Profile(Interop.CreateRGB(whitePoint, primaries, [.. transferFunction.Select(_ => _.Handle)]));
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace lcmsNET
         {
             if (transferFunction?.Length != 3) throw new ArgumentException($"'{nameof(transferFunction)}' array size must equal 3.");
 
-            return new Profile(Interop.CreateRGB(Helper.GetHandle(context), whitePoint, primaries, transferFunction.Select(_ => _.Handle).ToArray()), context);
+            return new Profile(Interop.CreateRGB(Helper.GetHandle(context), whitePoint, primaries, [.. transferFunction.Select(_ => _.Handle)]), context);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace lcmsNET
         /// </remarks>
         public static Profile CreateLinearizationDeviceLink(ColorSpaceSignature space, ToneCurve[] transferFunction)
         {
-            return new Profile(Interop.CreateLinearizationDeviceLink(Convert.ToUInt32(space), transferFunction.Select(_ => _.Handle).ToArray()));
+            return new Profile(Interop.CreateLinearizationDeviceLink(Convert.ToUInt32(space), [.. transferFunction.Select(_ => _.Handle)]));
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace lcmsNET
         public static Profile CreateLinearizationDeviceLink(Context context, ColorSpaceSignature space, ToneCurve[] transferFunction)
         {
             return new Profile(Interop.CreateLinearizationDeviceLink(Helper.GetHandle(context), Convert.ToUInt32(space),
-                    transferFunction.Select(_ => _.Handle).ToArray()), context);
+                    [.. transferFunction.Select(_ => _.Handle)]), context);
         }
 
         /// <summary>
@@ -860,10 +860,10 @@ namespace lcmsNET
 
             Type t = typeof(T);
             MethodInfo method = t.GetMethod("FromHandle", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static,
-                    null, new Type[] { typeof(IntPtr) }, null);
-            if (method is null) throw new MissingMethodException(nameof(T), "FromHandle(IntPtr)");
-
-            return (T)method.Invoke(null, new object[] { ptr });
+                    null, [typeof(IntPtr)], null);
+            return method is null
+                ? throw new MissingMethodException(nameof(T), "FromHandle(IntPtr)")
+                : (T)method.Invoke(null, [ptr]);
         }
 
         /// <summary>
@@ -963,10 +963,8 @@ namespace lcmsNET
             EnsureNotClosed();
 
             MethodInfo method = typeof(T).GetMethod("ToHandle", BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, new Type[] { }, null);
-            if (method is null) throw new MissingMethodException(nameof(T), "ToHandle()");
-
-            IntPtr ptr = (IntPtr)method.Invoke(t, new object[] { });
+                    null, [], null) ?? throw new MissingMethodException(nameof(T), "ToHandle()");
+            IntPtr ptr = (IntPtr)method.Invoke(t, []);
             try
             {
                 return WriteTag(tag, ptr);
@@ -1256,10 +1254,7 @@ namespace lcmsNET
             {
                 EnsureNotClosed();
 
-                if (_iohandler is null)
-                {
-                    _iohandler = new IOHandler(Interop.GetProfileIOHandler(handle), Context, isOwner: false);
-                }
+                _iohandler ??= new IOHandler(Interop.GetProfileIOHandler(handle), Context, isOwner: false);
                 return _iohandler;
             }
             private set

--- a/src/lcmsNET/ProfileSequenceDescriptor.cs
+++ b/src/lcmsNET/ProfileSequenceDescriptor.cs
@@ -28,6 +28,9 @@ namespace lcmsNET
     /// Represents a profile sequence descriptor.
     /// </summary>
     public sealed class ProfileSequenceDescriptor : TagBase<ProfileSequenceDescriptor>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<ProfileSequenceDescriptor>
+#endif
     {
         internal ProfileSequenceDescriptor(IntPtr handle, Context context = null, bool isOwner = true)
             : base(handle, context, isOwner)
@@ -46,7 +49,7 @@ namespace lcmsNET
         /// <exception cref="LcmsNETException">
         /// The <paramref name="handle"/> is <see cref="IntPtr.Zero"/>.
         /// </exception>
-        internal static ProfileSequenceDescriptor FromHandle(IntPtr handle)
+        public static ProfileSequenceDescriptor FromHandle(IntPtr handle)
         {
             return new ProfileSequenceDescriptor(handle, context: null, isOwner: false);
         }

--- a/src/lcmsNET/ProfileSequenceDescriptor.cs
+++ b/src/lcmsNET/ProfileSequenceDescriptor.cs
@@ -118,7 +118,7 @@ namespace lcmsNET
         private unsafe void CreateItems()
         {
             Items = new ProfileSequenceItem[Length];
-            int itemSize = Marshal.SizeOf(typeof(PSeqDesc));
+            int itemSize = Marshal.SizeOf<PSeqDesc>();
             byte* ptr = (byte*)SeqDesc->seq.ToPointer();
             for (uint i = 0; i < Length; i++)
             {

--- a/src/lcmsNET/Screening.cs
+++ b/src/lcmsNET/Screening.cs
@@ -110,6 +110,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct Screening
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<Screening>
+#endif
     {
         /// <summary>
         /// Screening flags.
@@ -132,7 +135,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="Screening"/> instance.</returns>
-        internal static Screening FromHandle(IntPtr handle)
+        public static Screening FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<Screening>(handle);
         }

--- a/src/lcmsNET/Signature.cs
+++ b/src/lcmsNET/Signature.cs
@@ -26,20 +26,18 @@ namespace lcmsNET
     /// <summary>
     /// Represents a signature.
     /// </summary>
+    /// <remarks>
+    /// Initialises a new instance of the <see cref="Signature"/> class.
+    /// </remarks>
+    /// <param name="u">The signature value.</param>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Signature
+    public readonly struct Signature(uint u)
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<Signature>
+#endif
     {
         [MarshalAs(UnmanagedType.U4)]
-        private readonly uint _;
-
-        /// <summary>
-        /// Initialises a new instance of the <see cref="Signature"/> class.
-        /// </summary>
-        /// <param name="u">The signature value.</param>
-        public Signature(uint u)
-        {
-            _ = u;
-        }
+        private readonly uint _ = u;
 
         /// <summary>
         /// Implicitly converts a <see cref="Signature"/> to an unsigned integer.
@@ -51,14 +49,14 @@ namespace lcmsNET
         /// Explicitly converts an unsigned integer to a <see cref="Signature"/>.
         /// </summary>
         /// <param name="u">The unsigned integer to be converted.</param>
-        public static explicit operator Signature(uint u) => new Signature(u);
+        public static explicit operator Signature(uint u) => new(u);
 
         /// <summary>
         /// Marshals data from an unmanaged block of memory to a newly allocated <see cref="Signature"/> object.
         /// </summary>
         /// <param name="handle">A handle to the unmanaged block of memory.</param>
         /// <returns>A new <see cref="Signature"/> instance.</returns>
-        internal static Signature FromHandle(IntPtr handle)
+        public static Signature FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<Signature>(handle);
         }

--- a/src/lcmsNET/Stage.cs
+++ b/src/lcmsNET/Stage.cs
@@ -162,7 +162,7 @@ namespace lcmsNET
         /// </remarks>
         public static Stage Create(Context context, double[,] matrix, double[] offset)
         {
-            if (!(offset is null) && offset.Length != (matrix?.GetUpperBound(1) + 1))
+            if (offset is not null && offset.Length != (matrix?.GetUpperBound(1) + 1))
             {
                 throw new ArgumentException($"'{nameof(offset)}' array size must equal size of '{nameof(matrix)}' second dimension.");
             }

--- a/src/lcmsNET/Tm.cs
+++ b/src/lcmsNET/Tm.cs
@@ -27,62 +27,48 @@ namespace lcmsNET
     /// Represents a calendar date and time broken into its components.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Tm
+    public unsafe struct Tm
     {
+        internal const int FILL_SIZE = 16;
+
         /// <summary>
         /// Seconds after the minute in the range 0..61.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int sec;
         /// <summary>
         /// Minutes after the hour in the range 0..59.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int min;
         /// <summary>
         /// Hours since midnight in the range 0..23.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int hour;
         /// <summary>
         /// Day of the month in the range 1..31.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int mday;
         /// <summary>
         /// Month of the year in the range 0..11.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int mon;
         /// <summary>
         /// Years since 1900.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int year;
         /// <summary>
         /// Days since Sunday in the range 0..6.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int wday;
         /// <summary>
         /// Days since January 1 in the range 0..365.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int yday;
         /// <summary>
         /// Daylight saving time flag. Greater than zero if Daylight Savings is in effect,
         /// zero if not in effect or less than zero if information is not available.
         /// </summary>
-        [MarshalAs(UnmanagedType.I4)]
         public int isdst;
-        // The glibc version of struct tm has additional fields
-        //   long tm_gmtoff;           /* Seconds east of UTC */
-        //   const char *tm_zone;      /* Timezone abbreviation */
-        // defined when _BSD_SOURCE was set before including <time.h>.
-        //
-        // Use filler to ensure sufficient size when marshaling this type in this runtime.
-        [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.U4, SizeConst = FILL_SIZE)]
-        private readonly byte[] fill;
+        private fixed byte fill[FILL_SIZE];
 
         /// <summary>
         /// Creates a <see cref="Tm"/> from the supplied handle.
@@ -129,7 +115,11 @@ namespace lcmsNET
             wday = (int)date.DayOfWeek;
             yday = date.DayOfYear - 1;
             isdst = -1;
-            fill = new byte[FILL_SIZE];
+            fixed (byte* p = fill)
+            {
+                for (int i = 0; i < FILL_SIZE; i++)
+                    p[i] = 0;
+            }
         }
 
         /// <summary>
@@ -142,7 +132,5 @@ namespace lcmsNET
             Interop.DecodeDateTimeNumber(in date, ref tm);
             this = tm;
         }
-
-        private const int FILL_SIZE = 16;
     }
 }

--- a/src/lcmsNET/Tm.cs
+++ b/src/lcmsNET/Tm.cs
@@ -28,6 +28,9 @@ namespace lcmsNET
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct Tm
+#if NET7_0_OR_GREATER
+        : ICreatableFromHandle<Tm>
+#endif
     {
         internal const int FILL_SIZE = 16;
 
@@ -75,7 +78,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to an existing calendar date and time.</param>
         /// <returns>A new <see cref="Tm"/> instance referencing an existing calendar date and time.</returns>
-        internal static Tm FromHandle(IntPtr handle)
+        public static Tm FromHandle(IntPtr handle)
         {
             return Marshal.PtrToStructure<Tm>(handle);
         }
@@ -128,7 +131,7 @@ namespace lcmsNET
         /// <param name="date">A <see cref="DateTimeNumber"/> instance.</param>
         public Tm(DateTimeNumber date)
         {
-            Tm tm = new Tm();
+            Tm tm = new();
             Interop.DecodeDateTimeNumber(in date, ref tm);
             this = tm;
         }

--- a/src/lcmsNET/ToneCurve.cs
+++ b/src/lcmsNET/ToneCurve.cs
@@ -75,6 +75,9 @@ namespace lcmsNET
     /// Represents a tone curve.
     /// </summary>
     public sealed class ToneCurve : TagBase<ToneCurve>
+#if NET7_0_OR_GREATER
+        , ICreatableFromHandle<ToneCurve>
+#endif
     {
         internal ToneCurve(IntPtr handle, Context context = null, bool isOwner = true)
             : base(handle, context, isOwner)

--- a/src/lcmsNET/Transform.cs
+++ b/src/lcmsNET/Transform.cs
@@ -169,7 +169,7 @@ namespace lcmsNET
                 Intent intent, CmsFlags flags)
         {
             return new Transform(Interop.CreateMultiprofileTransform(
-                    profiles.Select(_ => Helper.GetHandle(_)).ToArray(),
+                    [.. profiles.Select(_ => Helper.GetHandle(_))],
                     inputFormat, outputFormat, Convert.ToUInt32(intent), Convert.ToUInt32(flags)));
         }
 
@@ -195,7 +195,7 @@ namespace lcmsNET
                 Intent intent, CmsFlags flags)
         {
             return new Transform(Interop.CreateMultiprofileTransform(Helper.GetHandle(context),
-                    profiles.Select(_ => Helper.GetHandle(_)).ToArray(),
+                    [.. profiles.Select(_ => Helper.GetHandle(_))],
                     inputFormat, outputFormat, Convert.ToUInt32(intent), Convert.ToUInt32(flags)), context);
         }
 
@@ -230,9 +230,9 @@ namespace lcmsNET
                 double[] adaptationStates, Profile gamut, int gamutPCSPosition, uint inputFormat, uint outputFormat, CmsFlags flags)
         {
             return new Transform(Interop.CreateExtendedTransform(Helper.GetHandle(context),
-                    profiles.Select(_ => Helper.GetHandle(_)).ToArray(),
-                    bpc.Select(_ => _ ? 1 : 0).ToArray(),
-                    intents.Select(_ => Convert.ToUInt32(_)).ToArray(), adaptationStates, Helper.GetHandle(gamut),
+                    [.. profiles.Select(_ => Helper.GetHandle(_))],
+                    [.. bpc.Select(_ => _ ? 1 : 0)],
+                    [.. intents.Select(_ => Convert.ToUInt32(_))], adaptationStates, Helper.GetHandle(gamut),
                     gamutPCSPosition, inputFormat, outputFormat, Convert.ToUInt32(flags)), context);
         }
 

--- a/src/lcmsNET/UcrBg.cs
+++ b/src/lcmsNET/UcrBg.cs
@@ -28,7 +28,7 @@ namespace lcmsNET
     /// </summary>
     public sealed class UcrBg
 #if NET7_0_OR_GREATER
-        : IHandleConvertible
+        : IHandleConvertible, ICreatableFromHandle<UcrBg>
 #endif
     {
         /// <summary>
@@ -36,7 +36,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to an existing under color removal and black generation.</param>
         /// <returns>A new <see cref="UcrBg"/> instance referencing an existing under color removal and black generation.</returns>
-        internal static UcrBg FromHandle(IntPtr handle)
+        public static UcrBg FromHandle(IntPtr handle)
         {
             return new UcrBg(Marshal.PtrToStructure<PrivateUcrBg>(handle));
         }

--- a/src/lcmsNET/UcrBg.cs
+++ b/src/lcmsNET/UcrBg.cs
@@ -27,6 +27,9 @@ namespace lcmsNET
     /// Represents an under color removal and black generation.
     /// </summary>
     public sealed class UcrBg
+#if NET7_0_OR_GREATER
+        : IHandleConvertible
+#endif
     {
         /// <summary>
         /// Creates an under color removal and black generation from the supplied handle.
@@ -35,10 +38,10 @@ namespace lcmsNET
         /// <returns>A new <see cref="UcrBg"/> instance referencing an existing under color removal and black generation.</returns>
         internal static UcrBg FromHandle(IntPtr handle)
         {
-            return new UcrBg(Marshal.PtrToStructure<_ucrBg>(handle));
+            return new UcrBg(Marshal.PtrToStructure<PrivateUcrBg>(handle));
         }
 
-        private UcrBg(_ucrBg ucrBg)
+        private UcrBg(PrivateUcrBg ucrBg)
         {
             this.ucrBg = ucrBg;
             Ucr = ToneCurve.FromHandle(ucrBg.ucr);
@@ -77,21 +80,30 @@ namespace lcmsNET
         /// </summary>
         public MultiLocalizedUnicode Desc { get; private set; }
 
-        internal IntPtr ToHandle()
+        /// <summary>
+        /// Converts the current instance to a native handle that can be used by the underlying implementation.
+        /// </summary>
+        /// <returns>A native handle that represents the current instance.</returns>
+#if NET7_0_OR_GREATER
+        public
+#else
+        internal
+#endif
+            IntPtr ToHandle()
         {
-            int size = Marshal.SizeOf<_ucrBg>();
+            int size = Marshal.SizeOf<PrivateUcrBg>();
             IntPtr ptr = Marshal.AllocHGlobal(size);
             Marshal.StructureToPtr(ucrBg, ptr, false);
             return ptr;
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        private struct _ucrBg
+        private struct PrivateUcrBg
         {
             public IntPtr ucr;
             public IntPtr bg;
             public IntPtr desc;
         }
-        private _ucrBg ucrBg;
+        private PrivateUcrBg ucrBg;
     }
 }

--- a/src/lcmsNET/VideoCardGamma.cs
+++ b/src/lcmsNET/VideoCardGamma.cs
@@ -27,6 +27,9 @@ namespace lcmsNET
     /// Represents a video card gamma table.
     /// </summary>
     public sealed class VideoCardGamma
+#if NET7_0_OR_GREATER
+        : IHandleConvertible
+#endif
     {
         /// <summary>
         /// Creates a video card gamma table from the supplied handle.
@@ -35,10 +38,10 @@ namespace lcmsNET
         /// <returns>A new <see cref="VideoCardGamma"/> instance referencing an existing video card gamma table.</returns>
         internal static VideoCardGamma FromHandle(IntPtr handle)
         {
-            return new VideoCardGamma(Marshal.PtrToStructure<_vcgt>(handle));
+            return new VideoCardGamma(Marshal.PtrToStructure<Vcgt>(handle));
         }
 
-        private VideoCardGamma(_vcgt vcgt)
+        private VideoCardGamma(Vcgt vcgt)
         {
             this.vcgt = vcgt;
             Red = ToneCurve.FromHandle(vcgt.red);
@@ -77,21 +80,30 @@ namespace lcmsNET
         /// </summary>
         public ToneCurve Blue { get; private set; }
 
-        internal IntPtr ToHandle()
+        /// <summary>
+        /// Converts the current instance to a native handle that can be used by the underlying implementation.
+        /// </summary>
+        /// <returns>A native handle that represents the current instance.</returns>
+#if NET7_0_OR_GREATER
+        public
+#else
+        internal
+#endif
+            IntPtr ToHandle()
         {
-            int size = Marshal.SizeOf<_vcgt>();
+            int size = Marshal.SizeOf<Vcgt>();
             IntPtr ptr = Marshal.AllocHGlobal(size);
             Marshal.StructureToPtr(vcgt, ptr, false);
             return ptr;
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        private struct _vcgt
+        private struct Vcgt
         {
             public IntPtr red;
             public IntPtr green;
             public IntPtr blue;
         }
-        private _vcgt vcgt;
+        private Vcgt vcgt;
     }
 }

--- a/src/lcmsNET/VideoCardGamma.cs
+++ b/src/lcmsNET/VideoCardGamma.cs
@@ -28,7 +28,7 @@ namespace lcmsNET
     /// </summary>
     public sealed class VideoCardGamma
 #if NET7_0_OR_GREATER
-        : IHandleConvertible
+        : IHandleConvertible, ICreatableFromHandle<VideoCardGamma>
 #endif
     {
         /// <summary>
@@ -36,7 +36,7 @@ namespace lcmsNET
         /// </summary>
         /// <param name="handle">A handle to an existing video card gamma table.</param>
         /// <returns>A new <see cref="VideoCardGamma"/> instance referencing an existing video card gamma table.</returns>
-        internal static VideoCardGamma FromHandle(IntPtr handle)
+        public static VideoCardGamma FromHandle(IntPtr handle)
         {
             return new VideoCardGamma(Marshal.PtrToStructure<Vcgt>(handle));
         }

--- a/src/lcmsNET/lcmsNET.csproj
+++ b/src/lcmsNET/lcmsNET.csproj
@@ -23,6 +23,11 @@
     <PackageLicenseUrl></PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
+    <LangVersion>latest</LangVersion>
+    <DefineConstants>$(DefineConstants);LCMSNET_USE_LIBIMPORT;NET8_0</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\..\bin</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -40,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
 </Project>

--- a/src/lcmsNET/lcmsNET.csproj
+++ b/src/lcmsNET/lcmsNET.csproj
@@ -27,6 +27,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <OutputPath>..\..\bin</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/lcmsNET/lcmsNET.csproj
+++ b/src/lcmsNET/lcmsNET.csproj
@@ -19,12 +19,14 @@
     <PackageIconUrl>https://github.com/jrshoare/lcmsNET/raw/master/src/lcmsNET/icon.png</PackageIconUrl>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>keypair.snk</AssemblyOriginatorKeyFile>
-    <Copyright>Copyright (c) 2019-2025 John Stevenson-Hoare</Copyright>
+    <Copyright>Copyright (c) 2019-2026 John Stevenson-Hoare</Copyright>
     <PackageLicenseUrl></PackageLicenseUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <LangVersion>latest</LangVersion>
+    <IsAotCompatible>false</IsAotCompatible>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/lcmsNET/lcmsNET.csproj
+++ b/src/lcmsNET/lcmsNET.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
-    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
+    <Version>1.2.1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Authors>jrshoare</Authors>
     <Company />
@@ -25,7 +25,7 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <LangVersion>latest</LangVersion>
-    <IsAotCompatible>false</IsAotCompatible>
+    <IsAotCompatible>true</IsAotCompatible>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/lcmsNET/lcmsNET.csproj
+++ b/src/lcmsNET/lcmsNET.csproj
@@ -25,7 +25,6 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <LangVersion>latest</LangVersion>
-    <DefineConstants>$(DefineConstants);LCMSNET_USE_LIBIMPORT;NET8_0</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/tests/lcmsNET.Tests/ProfileTest.cs
+++ b/tests/lcmsNET.Tests/ProfileTest.cs
@@ -987,6 +987,7 @@ namespace lcmsNET.Tests
             Assert.AreEqual(expected, actual);
         }
 
+#if NETSTANDARD2_0_OR_GREATER
         [TestMethod()]
         public void ReadTagT_WhenFromHandleMethodMissing_ShouldThrowMissingMethodException()
         {
@@ -999,6 +1000,7 @@ namespace lcmsNET.Tests
             var actual = Assert.ThrowsException<MissingMethodException>(() =>
                 sut.ReadTag<TestCIEXYZ>(TagSignature.BlueColorant));
         }
+#endif
 
         [TestMethod()]
         public void ReadTagTTagNotFound()

--- a/tests/lcmsNET.Tests/StageTest.cs
+++ b/tests/lcmsNET.Tests/StageTest.cs
@@ -208,7 +208,7 @@ namespace lcmsNET.Tests
             using var sut = Stage.Create(context: null, nGridPoints: 9, inputChannels: 3, outputChannels: 3, (ushort[])null);
 
             // Act
-            var actual = sut.SampleCLUT((Sampler16)StageUtils.Sampler3D, cargo: nint.Zero, StageSamplingFlags.None);
+            var actual = sut.SampleCLUT((Sampler16)StageUtils.Sampler3D, cargo: IntPtr.Zero, StageSamplingFlags.None);
 
             // Assert
             Assert.IsTrue(actual);
@@ -221,7 +221,7 @@ namespace lcmsNET.Tests
             using var sut = Stage.Create(context: null, nGridPoints: 9, inputChannels: 3, outputChannels: 3, (float[])null);
 
             // Act
-            var actual = sut.SampleCLUT((SamplerFloat)StageUtils.Sampler3D, cargo: nint.Zero, StageSamplingFlags.None);
+            var actual = sut.SampleCLUT((SamplerFloat)StageUtils.Sampler3D, cargo: IntPtr.Zero, StageSamplingFlags.None);
 
             // Assert
             Assert.IsTrue(actual);

--- a/tests/lcmsNET.Tests/TestUtils/MultiLocalizedUnicodeUtils.cs
+++ b/tests/lcmsNET.Tests/TestUtils/MultiLocalizedUnicodeUtils.cs
@@ -22,17 +22,33 @@ namespace lcmsNET.Tests.TestUtils
 {
     public static class MultiLocalizedUnicodeUtils
     {
-        public record DisplayName(string Value, string LanguageCode = "en", string CountryCode = "GB");
+        // To ensure compatibility across frameworks without changing project settings,
+        // use this simple immutable class instead of a positional record.
+        public sealed class DisplayName
+        {
+            public string Value { get; }
+            public string LanguageCode { get; }
+            public string CountryCode { get; }
+
+            public DisplayName(string value, string languageCode = "en", string countryCode = "GB")
+            {
+                Value = value;
+                LanguageCode = languageCode;
+                CountryCode = countryCode;
+            }
+
+            public void Deconstruct(out string value, out string languageCode, out string countryCode)
+            {
+                value = Value;
+                languageCode = LanguageCode;
+                countryCode = CountryCode;
+            }
+
+            public override string ToString() => Value;
+        }
 
         public static MultiLocalizedUnicode CreateMultiLocalisedUnicode() =>
             MultiLocalizedUnicode.Create(null, 0);
-
-        public static MultiLocalizedUnicode CreateAsUTF8(DisplayName displayName)
-        {
-            var mlu = CreateMultiLocalisedUnicode();
-            mlu.SetUTF8(displayName.LanguageCode, displayName.CountryCode, displayName.Value);
-            return mlu;
-        }
 
         public static MultiLocalizedUnicode CreateAsWide(DisplayName displayName)
         {

--- a/tests/lcmsNET.Tests/lcmsNET.Tests.csproj
+++ b/tests/lcmsNET.Tests/lcmsNET.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>keypair.snk</AssemblyOriginatorKeyFile>
@@ -12,6 +12,15 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <OutputPath>..\..\bin</OutputPath>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Remove="Resources\Aqua.cube" />
     <None Remove="Resources\CIELABD50.icc" />


### PR DESCRIPTION
Replace DllImport with LibraryImport for NET 7+ builds to improve native AOT compatibility

#### PR Classification
This pull request introduces .NET 8 support, modernizes the codebase with new C# features, and improves interop and type safety.

#### PR Summary
The codebase is updated for .NET 8 compatibility, leveraging new C# features and source-generated interop, while maintaining .NET Standard 2.0 support.
- Profile.cs: Adds ICreatableFromHandle<T> and IHandleConvertible interfaces, updates tag read/write logic, and improves handle management.
- Interop/*.cs: Replaces DllImport with LibraryImport and UnmanagedCallConv for .NET 7+, updates P/Invoke signatures, and adds conditional compilation.
- MAT3.cs, VEC3.cs: Refactors struct layouts for blittability and source-generated interop compatibility.
- Project files: Bumps version, updates build settings for .NET 8, and enables multi-targeting for tests.
- Test and utility code: Replaces C# 9 records with classes and ensures cross-framework compatibility.
